### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
This PR updates go version to 1.23 addressing issue https://github.com/araujo88/golang-rest-api-template/issues/25.