### PR TITLE
Modify docker-compose to do not map volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+bin/
 *.exe
 *.exe~
 *.dll

--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ cd golang-rest-api-template
 3. Build and run the Docker containers
 
 ```bash
-make setup && make build && make up
+make up
 ```
+
+Please refer to the [Makefile](./Makefile) if you need to build in the local environment.
 
 ### Environment Variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - 8001:8001
-    volumes:
-      - .:/app
     depends_on:
       - db
       - mongo


### PR DESCRIPTION
Related to #31 

1. Delete Volumne mapping in docker-compose.yaml
2. modified .gitignore to include bin/
3. modified README

tested on my M1 macbook and Windows11 desktop