### PR TITLE
Add request id middleware and SQL-safe IDs

### DIFF
--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -22,6 +22,19 @@ type BookRepository interface {
 	DeleteBook(c *gin.Context)
 }
 
+func parseIDParam(c *gin.Context) (uint, bool) {
+	if c == nil {
+		return 0, false
+	}
+	value := c.Param("id")
+	id, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id format"})
+		return 0, false
+	}
+	return uint(id), true
+}
+
 // bookRepository holds shared resources like database and Redis client
 type bookRepository struct {
 	DB          database.Database
@@ -171,7 +184,12 @@ func (r *bookRepository) CreateBook(c *gin.Context) {
 func (r *bookRepository) FindBook(c *gin.Context) {
 	var book models.Book
 
-	if err := r.DB.Where("id = ?", c.Param("id")).First(&book).Error(); err != nil {
+	id, ok := parseIDParam(c)
+	if !ok {
+		return
+	}
+
+	if err := r.DB.Where("id = ?", id).First(&book).Error(); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
 		return
 	}
@@ -196,7 +214,12 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 	var book models.Book
 	var input models.UpdateBook
 
-	if err := r.DB.Where("id = ?", c.Param("id")).First(&book).Error(); err != nil {
+	id, ok := parseIDParam(c)
+	if !ok {
+		return
+	}
+
+	if err := r.DB.Where("id = ?", id).First(&book).Error(); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
 		return
 	}
@@ -224,7 +247,12 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 func (r *bookRepository) DeleteBook(c *gin.Context) {
 	var book models.Book
 
-	if err := r.DB.Where("id = ?", c.Param("id")).First(&book).Error(); err != nil {
+	id, ok := parseIDParam(c)
+	if !ok {
+		return
+	}
+
+	if err := r.DB.Where("id = ?", id).First(&book).Error(); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
 		return
 	}

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -173,7 +173,7 @@ func TestFindBook(t *testing.T) {
 
 	// Mock the Where method
 	mockDB.EXPECT().
-		Where("id = ?", "1").
+		Where("id = ?", uint(1)).
 		DoAndReturn(func(query interface{}, args ...interface{}) database.Database {
 			// Return mockDB to allow method chaining
 			return mockDB
@@ -216,6 +216,26 @@ func TestFindBook(t *testing.T) {
 	assert.Equal(t, expectedBook.Author, response.Data.Author)
 }
 
+func TestFindBookRejectsInvalidID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database.NewMockDatabase(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(mockDB, nil, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/book/:id", repo.FindBook)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/book/1%20OR%201=1", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid id format")
+}
+
 func TestDeleteBook(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -239,7 +259,7 @@ func TestDeleteBook(t *testing.T) {
 
 	// Mock Where to return the existingBook for chaining
 	mockDB.EXPECT().
-		Where("id = ?", "1").
+		Where("id = ?", uint(1)).
 		Return(mockDB).Times(1)
 
 	// Mock First to load the existingBook and return mockDB

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -30,6 +30,7 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 	userRepository := NewUserRepository(db, ctx)
 
 	r := gin.Default()
+	r.Use(middleware.RequestID())
 	r.Use(ContextMiddleware(bookRepository))
 
 	//r.Use(gin.Logger())

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -20,6 +20,7 @@ func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
 
 		// End timer
 		duration := time.Since(start)
+		requestID := GetRequestID(c)
 
 		// Log the request details
 		logger.Info("Request",
@@ -30,6 +31,7 @@ func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
 			zap.String("ip", c.ClientIP()),
 			zap.String("user-agent", c.Request.UserAgent()),
 			zap.String("errors", c.Errors.ByType(gin.ErrorTypePrivate).String()),
+			zap.String("request_id", requestID),
 		)
 
 		logEntry := bson.M{
@@ -40,6 +42,7 @@ func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
 			"ip":         c.ClientIP(),
 			"user-agent": c.Request.UserAgent(),
 			"errors":     c.Errors.ByType(gin.ErrorTypePrivate).String(),
+			"request_id": requestID,
 		}
 
 		// Log to MongoDB

--- a/pkg/middleware/request_id.go
+++ b/pkg/middleware/request_id.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const RequestIDHeader = "X-Request-Id"
+
+const requestIDGinKey = "request_id"
+
+type requestIDContextKey struct{}
+
+func newRequestID() string {
+	var b [16]byte
+	_, err := rand.Read(b[:])
+	if err != nil {
+		return ""
+	}
+
+	// Set version (4) and variant (10)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+
+	buf := make([]byte, 36)
+	hex.Encode(buf[0:8], b[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], b[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], b[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], b[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:36], b[10:16])
+	return string(buf)
+}
+
+// RequestID ensures every request has a stable request id.
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := strings.TrimSpace(c.GetHeader(RequestIDHeader))
+		if requestID == "" {
+			requestID = newRequestID()
+		}
+
+		if requestID == "" {
+			requestID = "unknown"
+		}
+
+		c.Set(requestIDGinKey, requestID)
+		c.Header(RequestIDHeader, requestID)
+		c.Request = c.Request.WithContext(context.WithValue(c.Request.Context(), requestIDContextKey{}, requestID))
+
+		c.Next()
+	}
+}
+
+// GetRequestID returns the request id stored in gin context.
+func GetRequestID(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	if value, ok := c.Get(requestIDGinKey); ok {
+		if requestID, ok := value.(string); ok {
+			return requestID
+		}
+	}
+	return ""
+}
+
+// GetRequestIDFromContext reads the request id from context.
+func GetRequestIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if value := ctx.Value(requestIDContextKey{}); value != nil {
+		if requestID, ok := value.(string); ok {
+			return requestID
+		}
+	}
+	return ""
+}

--- a/pkg/middleware/request_id_test.go
+++ b/pkg/middleware/request_id_test.go
@@ -1,0 +1,61 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestIDGenerated(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequestID())
+	r.GET("/test", func(c *gin.Context) {
+		id1 := GetRequestID(c)
+		id2 := GetRequestID(c)
+		ctxID := GetRequestIDFromContext(c.Request.Context())
+		c.JSON(http.StatusOK, gin.H{"id1": id1, "id2": id2, "ctx": ctxID})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	requestID := w.Header().Get(RequestIDHeader)
+	assert.NotEmpty(t, requestID)
+
+	var body map[string]string
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, requestID, body["id1"])
+	assert.Equal(t, requestID, body["id2"])
+	assert.Equal(t, requestID, body["ctx"])
+}
+
+func TestRequestIDPreserved(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequestID())
+	r.GET("/test", func(c *gin.Context) {
+		requestID := GetRequestID(c)
+		ctxID := GetRequestIDFromContext(c.Request.Context())
+		c.JSON(http.StatusOK, gin.H{"id": requestID, "ctx": ctxID})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Header.Set(RequestIDHeader, "req-123")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "req-123", w.Header().Get(RequestIDHeader))
+
+	var body map[string]string
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "req-123", body["id"])
+	assert.Equal(t, "req-123", body["ctx"])
+}


### PR DESCRIPTION
## Summary
- add request ID middleware with context/header propagation
- include request_id in zap and Mongo logs
- validate numeric book IDs and cover invalid input in tests

## Test plan
- not run (Go toolchain not installed on server)