### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -27,7 +27,7 @@ func parseIDParam(c *gin.Context) (uint, bool) {
 		return 0, false
 	}
 	value := c.Param("id")
-	id, err := strconv.ParseUint(value, 10, 64)
+	id, err := strconv.ParseUint(value, 10, strconv.IntSize)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id format"})
 		return 0, false


### PR DESCRIPTION
Potential fix for [https://github.com/LAA-Software-Engineering/golang-rest-api-template/security/code-scanning/2](https://github.com/LAA-Software-Engineering/golang-rest-api-template/security/code-scanning/2)

In general, to fix this type of issue you should ensure that the bit size passed to `strconv.ParseUint` does not exceed the bit size of the integer type you convert to, or you should add explicit upper/lower bound checks before casting. This prevents silent truncation and preserves the numeric value as intended.

In this specific case, `parseIDParam` returns `uint`. The safest and simplest fix without changing the rest of the functionality is to parse the value using `strconv.ParseUint` with a bit size that matches the size of `uint` on the target architecture. The Go standard library exposes `strconv.IntSize`, which is 32 or 64 depending on the architecture. By using that constant as the `bitSize` argument, we ensure that `ParseUint` never produces a value that cannot be represented by `uint`, making `uint(id)` safe and eliminating the risk of overflow. No behavior change occurs for valid IDs that fit in `uint`, and invalid/too-large IDs will now be rejected at parsing time.

Concretely, in `pkg/api/books.go`:
- Change line 30 from `strconv.ParseUint(value, 10, 64)` to use `strconv.IntSize` as the bit size: `strconv.ParseUint(value, 10, strconv.IntSize)`.
- The `strconv` package is already imported, so no new imports are needed.
- No other code in the file needs modification; the function signature and call sites remain the same.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
