### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/LAA-Software-Engineering/golang-rest-api-template/security/code-scanning/3](https://github.com/LAA-Software-Engineering/golang-rest-api-template/security/code-scanning/3)

In general, to fix this problem you add an explicit `permissions:` block either at the top level of the workflow (applies to all jobs) or inside the specific job(s), granting only the scopes actually required. For a simple build-and-test workflow that just checks out code and runs Go commands, `contents: read` is sufficient.

The best fix here, without changing existing functionality, is to add a workflow-level `permissions:` block directly under the `name: Go` line that sets `contents: read`. This ensures all jobs (currently just `build`) run with a read-only `GITHUB_TOKEN`, which is enough for `actions/checkout` and doesn’t affect the rest of the steps.

Concretely, in `.github/workflows/go.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 5 (`name: Go`). No additional imports or methods are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
