### PR TITLE
Fix SQL injection vulnerability in book lookup by ID

### DIFF
--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -189,7 +189,7 @@ func (r *bookRepository) FindBook(c *gin.Context) {
 		return
 	}
 
-	if err := r.DB.Where("id = ?", id).First(&book).Error(); err != nil {
+	if err := r.DB.FirstByID(&book, id).Error(); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
 		return
 	}
@@ -219,7 +219,7 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 		return
 	}
 
-	if err := r.DB.Where("id = ?", id).First(&book).Error(); err != nil {
+	if err := r.DB.FirstByID(&book, id).Error(); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
 		return
 	}
@@ -252,7 +252,7 @@ func (r *bookRepository) DeleteBook(c *gin.Context) {
 		return
 	}
 
-	if err := r.DB.Where("id = ?", id).First(&book).Error(); err != nil {
+	if err := r.DB.FirstByID(&book, id).Error(); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
 		return
 	}

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -171,18 +171,10 @@ func TestFindBook(t *testing.T) {
 
 	// Mock expectations
 
-	// Mock the Where method
+	// Mock the FirstByID method
 	mockDB.EXPECT().
-		Where("id = ?", uint(1)).
-		DoAndReturn(func(query interface{}, args ...interface{}) database.Database {
-			// Return mockDB to allow method chaining
-			return mockDB
-		}).Times(1)
-
-	// Mock the First method
-	mockDB.EXPECT().
-		First(gomock.Any()).
-		DoAndReturn(func(dest interface{}, conds ...interface{}) database.Database {
+		FirstByID(gomock.Any(), uint(1)).
+		DoAndReturn(func(dest interface{}, id uint) database.Database {
 			if b, ok := dest.(*models.Book); ok {
 				*b = expectedBook
 			}
@@ -257,15 +249,10 @@ func TestDeleteBook(t *testing.T) {
 		Author: "Test Author",
 	}
 
-	// Mock Where to return the existingBook for chaining
+	// Mock the FirstByID method to load the existingBook and return mockDB
 	mockDB.EXPECT().
-		Where("id = ?", uint(1)).
-		Return(mockDB).Times(1)
-
-	// Mock First to load the existingBook and return mockDB
-	mockDB.EXPECT().
-		First(gomock.Any()).
-		DoAndReturn(func(dest interface{}, conds ...interface{}) database.Database {
+		FirstByID(gomock.Any(), uint(1)).
+		DoAndReturn(func(dest interface{}, id uint) database.Database {
 			if b, ok := dest.(*models.Book); ok {
 				*b = existingBook
 			}

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -21,6 +21,7 @@ type Database interface {
 	Delete(interface{}, ...interface{}) *gorm.DB
 	Model(model interface{}) *gorm.DB
 	First(dest interface{}, conds ...interface{}) Database
+	FirstByID(dest interface{}, id uint) Database
 	Updates(interface{}) *gorm.DB
 	Order(value interface{}) *gorm.DB
 	Error() error
@@ -36,6 +37,10 @@ func (db *GormDatabase) Where(query interface{}, args ...interface{}) Database {
 
 func (db *GormDatabase) First(dest interface{}, conds ...interface{}) Database {
 	return &GormDatabase{db.DB.First(dest, conds...)}
+}
+
+func (db *GormDatabase) FirstByID(dest interface{}, id uint) Database {
+	return &GormDatabase{db.DB.First(dest, id)}
 }
 
 func (db *GormDatabase) Error() error {

--- a/pkg/database/db_mock.go
+++ b/pkg/database/db_mock.go
@@ -119,6 +119,20 @@ func (mr *MockDatabaseMockRecorder) First(dest interface{}, conds ...interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "First", reflect.TypeOf((*MockDatabase)(nil).First), varargs...)
 }
 
+// FirstByID mocks base method.
+func (m *MockDatabase) FirstByID(dest interface{}, id uint) Database {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FirstByID", dest, id)
+	ret0, _ := ret[0].(Database)
+	return ret0
+}
+
+// FirstByID indicates an expected call of FirstByID.
+func (mr *MockDatabaseMockRecorder) FirstByID(dest interface{}, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FirstByID", reflect.TypeOf((*MockDatabase)(nil).FirstByID), dest, id)
+}
+
 // Limit mocks base method.
 func (m *MockDatabase) Limit(limit int) *gorm.DB {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR addresses issue #42 by implementing a safe database lookup method to prevent SQL injection vulnerabilities.

Changes:
- Added FirstByID helper method in pkg/database/db.go for safe ID-based queries
- Updated book API in pkg/api/books.go to use the new safe method
- Modified tests and mocks accordingly

Closes #42