### PR TITLE
fix(auth): encode username in JWT claims for middleware

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -24,20 +24,15 @@ func HashPassword(password string) (string, error) {
 }
 
 func GenerateToken(username string) (string, error) {
-	// The expiration time after which the token will be invalid.
-	expirationTime := time.Now().Add(5 * time.Minute).Unix()
-
-	// Create the JWT claims, which includes the username and expiration time
-	claims := &jwt.StandardClaims{
-		// In JWT, the expiry time is expressed as unix milliseconds
-		ExpiresAt: expirationTime,
-		Issuer:    username,
+	expiresAt := time.Now().Add(5 * time.Minute).Unix()
+	claims := &Claims{
+		Username: username,
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: expiresAt,
+		},
 	}
 
-	// Declare the token with the algorithm used for signing, and the claims
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-
-	// Create the JWT string
 	tokenString, err := token.SignedString(JwtKey)
 
 	if err != nil {

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"testing"
 
+	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,6 +19,26 @@ func TestGenerateToken(t *testing.T) {
 	token, err := GenerateToken(user)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, token)
+}
+
+func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
+	const wantUser = "alice"
+	tokenStr, err := GenerateToken(wantUser)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	parsed := &Claims{}
+	token, err := jwt.ParseWithClaims(tokenStr, parsed, func(token *jwt.Token) (interface{}, error) {
+		return JwtKey, nil
+	})
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.True(t, token.Valid) {
+		return
+	}
+	assert.Equal(t, wantUser, parsed.Username)
 }
 
 func TestGenerateRandomKey(t *testing.T) {


### PR DESCRIPTION
`GenerateToken` now signs `auth.Claims` with `Username` and `ExpiresAt` so JWTAuth's `ParseWithClaims` populates `claims.Username` (previously only iss was set on `StandardClaims`).

Adds `TestGenerateTokenRoundTripUsernameClaim` (generate → parse → assert).

Closes LAA-Software-Engineering/golang-rest-api-template#74