### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## Summary
+
+<!-- What does this PR change and why? Link any design notes or prior discussion. -->
+
+## Type of change
+
+<!-- Mark the relevant option with an “x” (e.g. `- [x] Bug fix`). -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change (describe impact below)
+- [ ] Documentation only
+- [ ] Build / CI / tooling
+- [ ] Dependency update
+
+## How to test
+
+<!-- Steps you ran or reviewers should run. -->
+
+```bash
+go test ./... -race
+```
+
+<!-- If you changed HTTP behavior, Docker, or integration tests: -->
+
+```bash
+# optional: local stack
+# make up
+
+# optional: Python E2E (see README; requires BASE_URL and API_KEY)
+# pytest tests/
+```
+
+## Checklist
+
+- [ ] `go test ./... -race` passes locally
+- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
+- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
+- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
+- [ ] No new secrets, credentials, or production keys committed
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+-


### PR DESCRIPTION
## Summary

Adds [GitHub’s default PR template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) at `.github/pull_request_template.md` so new PRs get a consistent structure.

## What’s in the template

- Short **summary** prompt
- **Type of change** (bug fix, feature, breaking, docs, tooling, deps)
- **How to test** with `go test ./... -race` plus optional Docker / pytest notes matching this repo’s README
- **Checklist**: tests, Swagger regen when API changes, env var docs, Docker build, no secrets
- **Related issues** footer

No application code changes.

Made with [Cursor](https://cursor.com)