### PR TITLE
docs: add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by opening an issue on this repository and stating that the report is about conduct (maintainers will treat good-faith reports seriously and can follow up privately when appropriate). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thank you for helping improve this template. Contributions are welcome via issues and pull requests.
+
+## Before you start
+
+- Check existing [issues](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues) and pull requests to avoid duplicate work.
+- For larger changes, open an issue first so maintainers can agree on direction (see also the [README](./README.md)).
+
+## Development setup
+
+- **Go**: version declared in [`go.mod`](./go.mod) (module uses vendoring; prefer builds with `-mod=vendor` if that is your local default).
+- **Docker** (optional): for full stack parity with [`docker-compose.yml`](./docker-compose.yml).
+
+Useful commands:
+
+```bash
+go test ./... -race
+```
+
+```bash
+make test          # tests with coverage flags per Makefile
+make up            # run stack via Docker Compose
+```
+
+## Pull requests
+
+- Keep changes focused on one concern when possible.
+- Run **`go test ./... -race`** before opening a PR.
+- Match existing style (`gofmt`, package layout, naming).
+- If you change HTTP routes, request/response shapes, or models used in Swagger, regenerate API docs (see the `setup` target in the [`Makefile`](./Makefile) and `swag init` usage there) and include updated `docs/` artifacts if applicable.
+- Do not commit secrets, real credentials, or personal `.env` files.
+- New or changed environment variables should be reflected in the README (and `.env.example` when that file exists).
+
+Pull requests use the template under [`.github/pull_request_template.md`](.github/pull_request_template.md) when opened on GitHub.
+
+## Conduct
+
+This project follows the [Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the same terms as the project ([MIT License](./LICENSE)).


### PR DESCRIPTION
## Summary

Adds contributor-facing documentation aligned with this Go API template.

### CONTRIBUTING.md
- Where to discuss work (issues, larger changes)
- Local dev commands (`go test`, `make`)
- PR expectations: tests, `gofmt`, Swagger regen, no secrets, README/env docs
- Pointer to [.github/pull_request_template.md](.github/pull_request_template.md)
- Link to Code of Conduct and MIT license

### CODE_OF_CONDUCT.md
- [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) **2.1** (standard text)
- Enforcement contact: report via **GitHub issues** on this repo (with note that maintainers can follow up privately for sensitive reports)

No code changes.

Made with [Cursor](https://cursor.com)