### PR TITLE
fix(docker): align Go image with go.mod and Postgres data directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.21.0-bookworm
+# Align with go.mod and CI (see .github/workflows/go.yml).
+FROM golang:1.25-bookworm
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ services:
     restart: always
     container_name: dockerPostgres
     volumes:
-      - .dbdata:/var/lib/postgres
+      # Official postgres image stores cluster data under PGDATA (default /var/lib/postgresql/data).
+      - .dbdata:/var/lib/postgresql/data
     ports:
       - "5435:5435"
     environment:


### PR DESCRIPTION
## Summary

Aligns Docker tooling with the Go toolchain declared in `go.mod` (1.25) and fixes Postgres volume mounting so data persists under the path the official `postgres` image uses (`PGDATA`, default `/var/lib/postgresql/data`). Previously the image used `golang:1.21.0-bookworm` while CI and `go.mod` used Go 1.25, and the DB bind mount targeted `/var/lib/postgres`, which is not the standard data directory for the official image.

See [Issue #75](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/75).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [x] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

```bash
docker compose config -q
docker compose build
# optional: full stack
# make up
```

## Checklist

- [x] `go test ./... -race` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [x] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #75
