### PR TITLE
docs: add .env.example and fix README env var names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to `.env` and set real values. Do not commit `.env`.
+# Generate random values for JWT_SECRET_KEY and API_SECRET_KEY:
+#   go run ./scripts/generate_key.go
+#
+# With Docker Compose, set POSTGRES_HOST to the Postgres service name (e.g. dockerPostgres)
+# and REDIS_HOST to the Redis service name (e.g. redis). For `make run-local`, use localhost.
+
+POSTGRES_HOST=localhost
+POSTGRES_DB=go_app_dev
+POSTGRES_USER=docker
+POSTGRES_PASSWORD=replace-me
+POSTGRES_PORT=5435
+
+REDIS_HOST=localhost
+
+# HMAC secret for signing JWTs (must match what the server loads at startup)
+JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
+
+# Shared secret for routes that validate the X-API-Key header
+API_SECRET_KEY=replace-me-generate-with-scripts-generate-key

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ golang-rest-api-template/
 │     ├── book.go
 │     └── user.go
 ├── README.md
+├── .env.example
 ├── scripts
-│  ├── generate_key
 │  └── generate_key.go
 └── vendor
 ```
@@ -103,15 +103,28 @@ Please refer to the [Makefile](./Makefile) if you need to build in the local env
 
 ### Environment Variables
 
-You can set the environment variables in the `.env` file. Here are some important variables:
+Copy [`.env.example`](./.env.example) to `.env`, adjust values for your environment, and load them into the process environment (for example `set -a && . ./.env && set +a` in Bash, or `docker compose --env-file .env up` so Compose picks up substitutions). **Do not commit `.env`.**
 
-- `POSTGRES_HOST`
-- `POSTGRES_DB`
-- `POSTGRES_USER`
-- `POSTGRES_PASSWORD`
-- `POSTGRES_PORT`
-- `JWT_SECRET`
-- `API_SECRET_KEY`
+Names below match `os.Getenv` usage in this repository:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `POSTGRES_HOST` | PostgreSQL hostname (e.g. `localhost` locally, service name in Compose) |
+| `POSTGRES_DB` | Database name |
+| `POSTGRES_USER` | Database user |
+| `POSTGRES_PASSWORD` | Database password |
+| `POSTGRES_PORT` | PostgreSQL port |
+| `REDIS_HOST` | Redis hostname (the app appends `:6379`; see `pkg/cache/cache.go`) |
+| `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
+| `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
+
+To generate URL-safe random values for `JWT_SECRET_KEY` and `API_SECRET_KEY`, run:
+
+```bash
+go run ./scripts/generate_key.go
+```
+
+`docker-compose.yml` and the `run-local` target in the [Makefile](./Makefile) ship **demo-only** credentials so the stack starts quickly. Replace them with generated secrets for anything beyond local experimentation.
 
 ### API Documentation
 


### PR DESCRIPTION
## Summary

Adds [`.env.example`](./.env.example) with every variable read via `os.Getenv` in application packages (Postgres, Redis, `JWT_SECRET_KEY`, `API_SECRET_KEY`), using placeholders and comments that point to `go run ./scripts/generate_key.go`.

Updates the README environment section so names match the code (fixes `JWT_SECRET` → `JWT_SECRET_KEY`, documents `REDIS_HOST`), links to `.env.example`, and notes that `docker-compose.yml` / `Makefile` `run-local` still carry demo-only credentials for quick local use.

Implements [issue #77](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/77).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [x] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

```bash
# optional: local stack
# make up

# optional: Python E2E (see README; requires BASE_URL and API_KEY)
# pytest tests/
```

## Checklist

- [x] `go test ./... -race` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [x] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #77
