### PR TITLE
fix(api): require JWT on book update and delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,21 @@ http://localhost:8001/swagger/index.html
 
 ### Authentication
 
-To use authenticated routes, you must include the `Authorization` header with the JWT token.
+All versioned routes expect the `X-API-Key` header matching `API_SECRET_KEY` (service-to-service gate).
+
+Book **mutations** (`POST`, `PUT`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain via `/api/v1/register` and `/api/v1/login`). Book **reads** (`GET` list and `GET` by id) require the API key only.
 
 ```bash
-curl -H "Authorization: Bearer <YOUR_TOKEN>" http://localhost:8001/api/v1/books
+curl -H "X-API-Key: <YOUR_API_KEY>" http://localhost:8001/api/v1/books
+```
+
+```bash
+curl -X POST \
+  -H "X-API-Key: <YOUR_API_KEY>" \
+  -H "Authorization: Bearer <YOUR_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Example","author":"Author"}' \
+  http://localhost:8001/api/v1/books
 ```
 
 ## Contributing

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -186,6 +186,9 @@ const docTemplate = `{
                 "security": [
                     {
                         "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
                     }
                 ],
                 "description": "Update the book details for the given ID",
@@ -230,6 +233,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "book not found",
                         "schema": {
@@ -242,6 +251,9 @@ const docTemplate = `{
                 "security": [
                     {
                         "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
                     }
                 ],
                 "description": "Delete the book with the given ID",
@@ -264,6 +276,12 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "Successfully deleted book",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "string"
                         }
@@ -364,7 +382,7 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "Successfully registered",
                         "schema": {
                             "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -180,6 +180,9 @@
                 "security": [
                     {
                         "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
                     }
                 ],
                 "description": "Update the book details for the given ID",
@@ -224,6 +227,12 @@
                             "type": "string"
                         }
                     },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "book not found",
                         "schema": {
@@ -236,6 +245,9 @@
                 "security": [
                     {
                         "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
                     }
                 ],
                 "description": "Delete the book with the given ID",
@@ -258,6 +270,12 @@
                 "responses": {
                     "204": {
                         "description": "Successfully deleted book",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "string"
                         }
@@ -358,7 +376,7 @@
                     }
                 ],
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "Successfully registered",
                         "schema": {
                             "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -148,12 +148,17 @@ paths:
           description: Successfully deleted book
           schema:
             type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
         "404":
           description: book not found
           schema:
             type: string
       security:
       - ApiKeyAuth: []
+      - JwtAuth: []
       summary: Delete a book by ID
       tags:
       - books
@@ -208,12 +213,17 @@ paths:
           description: Bad Request
           schema:
             type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
         "404":
           description: book not found
           schema:
             type: string
       security:
       - ApiKeyAuth: []
+      - JwtAuth: []
       summary: Update a book by ID
       tags:
       - books
@@ -269,7 +279,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "201":
           description: Successfully registered
           schema:
             type: string

--- a/pkg/api/book_routes_auth_test.go
+++ b/pkg/api/book_routes_auth_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/middleware"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// testBookWriteMiddlewareStack mirrors NewRouter book mutation middleware so
+// JWT requirements stay aligned with production routes.
+func testBookWriteMiddlewareStack(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	ok := func(c *gin.Context) {
+		switch c.Request.Method {
+		case http.MethodDelete:
+			c.Status(http.StatusNoContent)
+		default:
+			c.Status(http.StatusOK)
+		}
+	}
+	r.PUT("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
+	r.DELETE("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
+	return r
+}
+
+func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
+	const apiKey = "book-auth-test-api-secret"
+	t.Setenv("API_SECRET_KEY", apiKey)
+
+	token, err := auth.GenerateToken("book-writer")
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		apiKeyHdr  string
+		authzHdr   string
+		wantStatus int
+		wantErrSub string
+	}{
+		{
+			name:       "put missing api key",
+			method:     http.MethodPut,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Unauthorized",
+		},
+		{
+			name:       "put wrong api key",
+			method:     http.MethodPut,
+			apiKeyHdr:  "not-the-secret",
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Unauthorized",
+		},
+		{
+			name:       "put api key only no jwt",
+			method:     http.MethodPut,
+			apiKeyHdr:  apiKey,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Missing Authorization Header",
+		},
+		{
+			name:       "put invalid bearer prefix",
+			method:     http.MethodPut,
+			apiKeyHdr:  apiKey,
+			authzHdr:   "Token " + token,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Invalid Authorization Header",
+		},
+		{
+			name:       "put garbage jwt",
+			method:     http.MethodPut,
+			apiKeyHdr:  apiKey,
+			authzHdr:   "Bearer not-a-jwt",
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Invalid token",
+		},
+		{
+			name:       "put valid api key and jwt",
+			method:     http.MethodPut,
+			apiKeyHdr:  apiKey,
+			authzHdr:   "Bearer " + token,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "delete api key only no jwt",
+			method:     http.MethodDelete,
+			apiKeyHdr:  apiKey,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Missing Authorization Header",
+		},
+		{
+			name:       "delete valid api key and jwt",
+			method:     http.MethodDelete,
+			apiKeyHdr:  apiKey,
+			authzHdr:   "Bearer " + token,
+			wantStatus: http.StatusNoContent,
+		},
+	}
+
+	r := testBookWriteMiddlewareStack(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/v1/books/1", nil)
+			if tt.apiKeyHdr != "" {
+				req.Header.Set("X-API-Key", tt.apiKeyHdr)
+			}
+			if tt.authzHdr != "" {
+				req.Header.Set("Authorization", tt.authzHdr)
+			}
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != tt.wantStatus {
+				t.Fatalf("status: got %d want %d body=%q", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if tt.wantErrSub != "" {
+				var body map[string]any
+				if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+					t.Fatalf("json body: %v raw=%q", err, w.Body.String())
+				}
+				errVal, _ := body["error"].(string)
+				if !strings.Contains(errVal, tt.wantErrSub) {
+					t.Fatalf("error: got %q want substring %q", errVal, tt.wantErrSub)
+				}
+			}
+		})
+	}
+}
+
+func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
+	const apiKey = "book-auth-test-api-secret-2"
+	t.Setenv("API_SECRET_KEY", apiKey)
+
+	token, err := auth.GenerateToken("u1")
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if len(token) < 20 {
+		t.Fatalf("unexpected short token")
+	}
+
+	valid := "Bearer " + token
+	badSig := "Bearer " + token[:len(token)-4]
+
+	r := testBookWriteMiddlewareStack(t)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/books/1", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	req.Header.Set("Authorization", badSig)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 for tampered token, got %d body=%q", rec.Code, rec.Body.String())
+	}
+
+	req2 := httptest.NewRequest(http.MethodPut, "/api/v1/books/1", nil)
+	req2.Header.Set("X-API-Key", apiKey)
+	req2.Header.Set("Authorization", valid)
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("want 200 for valid token, got %d", rec2.Code)
+	}
+}
+
+func TestBookWriteRoutesConcurrentAuthorizedRequests(t *testing.T) {
+	const apiKey = "book-auth-test-api-secret-concurrent"
+	t.Setenv("API_SECRET_KEY", apiKey)
+
+	token, err := auth.GenerateToken("concurrent-user")
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	r := testBookWriteMiddlewareStack(t)
+	const workers = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/books/1", nil)
+			req.Header.Set("X-API-Key", apiKey)
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				errs <- errTestStatus{got: w.Code, body: w.Body.String()}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		if e != nil {
+			t.Fatal(e)
+		}
+	}
+}
+
+type errTestStatus struct {
+	got  int
+	body string
+}
+
+func (e errTestStatus) Error() string {
+	return fmt.Sprintf("unexpected HTTP status %d, body=%s", e.got, e.body)
+}

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -207,12 +207,14 @@ func (r *bookRepository) FindBook(c *gin.Context) {
 // @Description Update the book details for the given ID
 // @Tags books
 // @Security ApiKeyAuth
+// @Security JwtAuth
 // @Accept  json
 // @Produce  json
 // @Param id path string true "Book ID"
 // @Param input body models.UpdateBook true "Update book object"
 // @Success 200 {object} models.Book "Successfully updated book"
 // @Failure 400 {string} string "Bad Request"
+// @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {string} string "book not found"
 // @Router /books/{id} [put]
 func (r *bookRepository) UpdateBook(c *gin.Context) {
@@ -244,9 +246,11 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 // @Description Delete the book with the given ID
 // @Tags books
 // @Security ApiKeyAuth
+// @Security JwtAuth
 // @Produce json
 // @Param id path string true "Book ID"
 // @Success 204 {string} string "Successfully deleted book"
+// @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {string} string "book not found"
 // @Router /books/{id} [delete]
 func (r *bookRepository) DeleteBook(c *gin.Context) {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -49,8 +49,8 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 		v1.GET("/books", middleware.APIKeyAuth(), bookRepository.FindBooks)
 		v1.POST("/books", middleware.APIKeyAuth(), middleware.JWTAuth(), bookRepository.CreateBook)
 		v1.GET("/books/:id", middleware.APIKeyAuth(), bookRepository.FindBook)
-		v1.PUT("/books/:id", middleware.APIKeyAuth(), bookRepository.UpdateBook)
-		v1.DELETE("/books/:id", middleware.APIKeyAuth(), bookRepository.DeleteBook)
+		v1.PUT("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), bookRepository.UpdateBook)
+		v1.DELETE("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), bookRepository.DeleteBook)
 
 		v1.POST("/login", middleware.APIKeyAuth(), userRepository.LoginHandler)
 		v1.POST("/register", middleware.APIKeyAuth(), userRepository.RegisterHandler)


### PR DESCRIPTION
## Summary

`PUT` and `DELETE` on `/api/v1/books/:id` previously accepted **only** `X-API-Key`, while `POST /api/v1/books` required API key **and** JWT. This aligned mutations with `POST` by adding `JWTAuth()` after `APIKeyAuth()` on update and delete routes.

Swagger annotations and generated `docs/` now list both `ApiKeyAuth` and `JwtAuth` for those operations. README documents the split: API key for all v1 routes; JWT additionally required for book writes. New tests in `pkg/api/book_routes_auth_test.go` exercise the same middleware stack (failure paths, tampered JWT, concurrent authorized requests).

Refs: https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/78

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change:** Clients that called `PUT` or `DELETE` with only `X-API-Key` must now send `Authorization: Bearer <JWT>` (same as `POST /books`). Book `GET` routes are unchanged (API key only).

## How to test

```bash
go test ./... -race
go vet ./...
```

```bash
# optional: local stack
# make up

# optional: Python E2E (see README; requires BASE_URL and API_KEY)
# pytest tests/
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #78
