### PR TITLE
fix(security): validate JWT signing algorithm (HS256 only)

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 	"os"
 	"time"
 
@@ -17,6 +18,19 @@ type Claims struct {
 }
 
 var JwtKey = []byte(os.Getenv("JWT_SECRET_KEY"))
+
+// JWTKeyFunc returns a jwt.Keyfunc for ParseWithClaims that only accepts
+// tokens signed with HMAC-SHA256 using key. Any other signing method
+// (including "none" and asymmetric algorithms) is rejected to prevent
+// algorithm confusion attacks.
+func JWTKeyFunc(key []byte) jwt.Keyfunc {
+	return func(token *jwt.Token) (interface{}, error) {
+		if token.Method != jwt.SigningMethodHS256 {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return key, nil
+	}
+}
 
 func HashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt"
 	"github.com/stretchr/testify/assert"
@@ -29,9 +30,7 @@ func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
 	}
 
 	parsed := &Claims{}
-	token, err := jwt.ParseWithClaims(tokenStr, parsed, func(token *jwt.Token) (interface{}, error) {
-		return JwtKey, nil
-	})
+	token, err := jwt.ParseWithClaims(tokenStr, parsed, JWTKeyFunc(JwtKey))
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -45,4 +44,61 @@ func TestGenerateRandomKey(t *testing.T) {
 	randomKey := GenerateRandomKey()
 	assert.NotEmpty(t, randomKey)
 	assert.Len(t, randomKey, 44)
+}
+
+func TestJWTKeyFuncRejectsNonHS256Algorithms(t *testing.T) {
+	key := []byte("jwt-keyfunc-test-secret-32bytes!!")
+	exp := time.Now().Add(time.Hour).Unix()
+	baseClaims := Claims{
+		Username: "attacker",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: exp,
+		},
+	}
+
+	t.Run("HS512", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodHS512, &baseClaims)
+		s, err := tok.SignedString(key)
+		if !assert.NoError(t, err) {
+			return
+		}
+		parsed := &Claims{}
+		_, err = jwt.ParseWithClaims(s, parsed, JWTKeyFunc(key))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected signing method")
+	})
+
+	t.Run("none", func(t *testing.T) {
+		tok := jwt.NewWithClaims(jwt.SigningMethodNone, &baseClaims)
+		s, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+		if !assert.NoError(t, err) {
+			return
+		}
+		parsed := &Claims{}
+		_, err = jwt.ParseWithClaims(s, parsed, JWTKeyFunc(key))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unexpected signing method")
+	})
+}
+
+func TestJWTKeyFuncAcceptsHS256(t *testing.T) {
+	key := []byte("jwt-keyfunc-hs256-accept-secret!")
+	claims := &Claims{
+		Username: "legit",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Hour).Unix(),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(key)
+	if !assert.NoError(t, err) {
+		return
+	}
+	parsed := &Claims{}
+	token, err := jwt.ParseWithClaims(s, parsed, JWTKeyFunc(key))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.True(t, token.Valid)
+	assert.Equal(t, "legit", parsed.Username)
 }

--- a/pkg/middleware/authenticateJWT.go
+++ b/pkg/middleware/authenticateJWT.go
@@ -9,6 +9,9 @@ import (
 	"github.com/golang-jwt/jwt"
 )
 
+// JWTAuth returns Gin middleware that requires a valid Bearer JWT signed
+// with HMAC-SHA256 using the application's JWT secret. Other algorithms are
+// rejected before signature verification.
 func JWTAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		const BearerSchema = "Bearer "
@@ -28,9 +31,7 @@ func JWTAuth() gin.HandlerFunc {
 		tokenStr := header[len(BearerSchema):]
 		claims := &auth.Claims{}
 
-		token, err := jwt.ParseWithClaims(tokenStr, claims, func(token *jwt.Token) (interface{}, error) {
-			return auth.JwtKey, nil
-		})
+		token, err := jwt.ParseWithClaims(tokenStr, claims, auth.JWTKeyFunc(auth.JwtKey))
 
 		if err != nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})

--- a/pkg/middleware/authenticateJWT_test.go
+++ b/pkg/middleware/authenticateJWT_test.go
@@ -1,0 +1,194 @@
+package middleware
+
+import (
+	"encoding/json"
+	"golang-rest-api-template/pkg/auth"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+)
+
+func testRouterJWTAuthOnly(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/protected", JWTAuth(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+func TestJWTAuthValidBearer(t *testing.T) {
+	token, err := auth.GenerateToken("middleware-user")
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	r := testRouterJWTAuthOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestJWTAuthSetsUsernameContext(t *testing.T) {
+	const wantUser = "ctx-user"
+	token, err := auth.GenerateToken(wantUser)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	var got string
+	r.GET("/p", JWTAuth(), func(c *gin.Context) {
+		v, ok := c.Get("username")
+		if !ok {
+			t.Error("username not in context")
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		got, _ = v.(string)
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/p", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got != wantUser {
+		t.Fatalf("username: got %q want %q", got, wantUser)
+	}
+}
+
+func TestJWTAuthRejectsBadRequests(t *testing.T) {
+	validHS256, err := auth.GenerateToken("ok-user")
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	key := auth.JwtKey
+	exp := time.Now().Add(time.Hour).Unix()
+	claims := &auth.Claims{
+		Username: "other",
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: exp,
+		},
+	}
+	hs512 := jwt.NewWithClaims(jwt.SigningMethodHS512, claims)
+	hs512Str, err := hs512.SignedString(key)
+	if err != nil {
+		t.Fatalf("HS512 token: %v", err)
+	}
+	noneTok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	noneStr, err := noneTok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("none token: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		authz      string
+		wantStatus int
+		wantErrSub string
+	}{
+		{
+			name:       "missing authorization",
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Missing Authorization Header",
+		},
+		{
+			name:       "invalid bearer prefix",
+			authz:      "Token " + validHS256,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Invalid Authorization Header",
+		},
+		{
+			name:       "malformed jwt",
+			authz:      "Bearer not-a-jwt",
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Invalid token",
+		},
+		{
+			name:       "HS512 algorithm",
+			authz:      "Bearer " + hs512Str,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Invalid token",
+		},
+		{
+			name:       "none algorithm",
+			authz:      "Bearer " + noneStr,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Invalid token",
+		},
+		{
+			name:       "valid HS256",
+			authz:      "Bearer " + validHS256,
+			wantStatus: http.StatusOK,
+		},
+	}
+
+	r := testRouterJWTAuthOnly(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			if tt.authz != "" {
+				req.Header.Set("Authorization", tt.authz)
+			}
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status: got %d want %d body=%q", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantErrSub != "" {
+				var body map[string]any
+				if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+					t.Fatalf("json: %v raw=%q", err, rec.Body.String())
+				}
+				errVal, _ := body["error"].(string)
+				if !strings.Contains(errVal, tt.wantErrSub) {
+					t.Fatalf("error: got %q want substring %q", errVal, tt.wantErrSub)
+				}
+			}
+		})
+	}
+}
+
+func TestJWTAuthConcurrentValidRequests(t *testing.T) {
+	token, err := auth.GenerateToken("concurrent-jwt-user")
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	r := testRouterJWTAuthOnly(t)
+	const workers = 32
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				errs <- w.Body.String()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		if msg != "" {
+			t.Fatalf("unexpected failure body=%q", msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Enforces **HMAC-SHA256 only** when parsing JWTs in \`JWTAuth\` by using \`auth.JWTKeyFunc\`, which rejects any token whose signing method is not \`jwt.SigningMethodHS256\` before signature verification. Mitigates algorithm confusion (e.g. \`alg: none\`, wrong HMAC family) per [#89](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/89).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

\`\`\`bash
go test ./... -race
\`\`\`

\`\`\`bash
go test ./pkg/auth ./pkg/middleware -race -count=1
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #89