### PR TITLE
fix(security): fail-fast JWT secret; remove package-init JwtKey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,8 @@ REDIS_HOST=localhost
 # MongoDB connection string (use mongodb://mongo:27017 when the API runs inside Compose)
 MONGODB_URI=mongodb://localhost:27017
 
-# HMAC secret for signing JWTs (must match what the server loads at startup)
+# HMAC secret for signing JWTs (raw string length must be at least 32 bytes).
+# Generate with: go run ./scripts/generate_key.go
 JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
 # Shared secret for routes that validate the X-API-Key header

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"golang-rest-api-template/pkg/api"
+	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/database"
 	"log"
+	"os"
 
 	"go.uber.org/zap"
 
@@ -38,6 +40,10 @@ import (
 // @externalDocs.description  OpenAPI
 // @externalDocs.url          https://swagger.io/resources/open-api/
 func main() {
+	if err := auth.SetJWTSigningKey([]byte(os.Getenv("JWT_SECRET_KEY"))); err != nil {
+		log.Fatalf("invalid JWT_SECRET_KEY: %v", err)
+	}
+
 	redisClient := cache.NewRedisClient()
 	db := database.NewDatabase()
 	dbWrapper := &database.GormDatabase{DB: db}

--- a/pkg/api/main_test.go
+++ b/pkg/api/main_test.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"golang-rest-api-template/pkg/auth"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	if err := auth.SetJWTSigningKey(bytes.Repeat([]byte("t"), auth.MinJWTSecretKeyBytes)); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -9,7 +9,6 @@ import (
 	"golang-rest-api-template/pkg/models"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"gorm.io/gorm"
@@ -34,7 +33,6 @@ func TestNewUserRepository(t *testing.T) {
 }
 
 func TestLoginHandlerSuccess(t *testing.T) {
-	os.Setenv("JWT_SECRET_KEY", "testkey")
 	// Set up real in-memory DB
 	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
 	if err != nil {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -3,12 +3,30 @@ package auth
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
-	"os"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/crypto/bcrypt"
+)
+
+// MinJWTSecretKeyBytes is the minimum accepted length for the HMAC JWT signing
+// secret (raw bytes, not base64-decoded length).
+const MinJWTSecretKeyBytes = 32
+
+var (
+	// ErrJWTSigningKeyNotConfigured is returned by GenerateToken when
+	// SetJWTSigningKey has not been called successfully.
+	ErrJWTSigningKeyNotConfigured = errors.New("jwt signing key not configured")
+
+	// ErrJWTSigningKeyTooShort is returned by SetJWTSigningKey when the secret
+	// is shorter than MinJWTSecretKeyBytes.
+	ErrJWTSigningKeyTooShort = errors.New("jwt signing key below minimum length")
+
+	signingMu     sync.RWMutex
+	jwtSigningKey []byte
 )
 
 // Claims carries custom JWT fields plus registered (standard) JWT claims.
@@ -17,7 +35,42 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
-var JwtKey = []byte(os.Getenv("JWT_SECRET_KEY"))
+// SetJWTSigningKey configures the symmetric key used to sign and verify JWTs.
+// It must be called once during application startup with a secret of at least
+// MinJWTSecretKeyBytes; otherwise GenerateToken and JWT middleware cannot work.
+func SetJWTSigningKey(secret []byte) error {
+	if len(secret) < MinJWTSecretKeyBytes {
+		return fmt.Errorf("%w: got %d bytes, need at least %d", ErrJWTSigningKeyTooShort, len(secret), MinJWTSecretKeyBytes)
+	}
+	k := make([]byte, len(secret))
+	copy(k, secret)
+	signingMu.Lock()
+	jwtSigningKey = k
+	signingMu.Unlock()
+	return nil
+}
+
+// JWTSigningKey returns a copy of the configured JWT HMAC secret, or nil if
+// SetJWTSigningKey has not completed successfully.
+func JWTSigningKey() []byte {
+	signingMu.RLock()
+	defer signingMu.RUnlock()
+	if len(jwtSigningKey) == 0 {
+		return nil
+	}
+	out := make([]byte, len(jwtSigningKey))
+	copy(out, jwtSigningKey)
+	return out
+}
+
+// ClearJWTSigningKeyForTesting drops the configured signing key. It is only
+// intended for tests that cover misconfiguration; callers must restore a valid
+// key (for example via t.Cleanup and SetJWTSigningKey).
+func ClearJWTSigningKeyForTesting() {
+	signingMu.Lock()
+	jwtSigningKey = nil
+	signingMu.Unlock()
+}
 
 // JWTKeyFunc returns a jwt.Keyfunc for ParseWithClaims that only accepts
 // tokens signed with HMAC-SHA256 using key. Any other signing method
@@ -38,6 +91,13 @@ func HashPassword(password string) (string, error) {
 }
 
 func GenerateToken(username string) (string, error) {
+	signingMu.RLock()
+	key := jwtSigningKey
+	signingMu.RUnlock()
+	if len(key) < MinJWTSecretKeyBytes {
+		return "", fmt.Errorf("auth.GenerateToken: %w", ErrJWTSigningKeyNotConfigured)
+	}
+
 	exp := time.Now().Add(5 * time.Minute)
 	claims := &Claims{
 		Username: username,
@@ -47,7 +107,7 @@ func GenerateToken(username string) (string, error) {
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString(JwtKey)
+	tokenString, err := token.SignedString(key)
 
 	if err != nil {
 		return "", err

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,12 +1,23 @@
 package auth
 
 import (
+	"bytes"
+	"errors"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	// Same-length key as production minimum; tests do not read JWT_SECRET_KEY at init.
+	if err := SetJWTSigningKey(bytes.Repeat([]byte("k"), MinJWTSecretKeyBytes)); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
 
 func TestHashPassword(t *testing.T) {
 	password := "1234"
@@ -30,7 +41,7 @@ func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
 	}
 
 	parsed := &Claims{}
-	token, err := jwt.ParseWithClaims(tokenStr, parsed, JWTKeyFunc(JwtKey))
+	token, err := jwt.ParseWithClaims(tokenStr, parsed, JWTKeyFunc(JWTSigningKey()))
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -44,6 +55,38 @@ func TestGenerateRandomKey(t *testing.T) {
 	randomKey := GenerateRandomKey()
 	assert.NotEmpty(t, randomKey)
 	assert.Len(t, randomKey, 44)
+}
+
+func TestSetJWTSigningKeyRejectsShortSecret(t *testing.T) {
+	before := JWTSigningKey()
+	err := SetJWTSigningKey(bytes.Repeat([]byte("s"), MinJWTSecretKeyBytes-1))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrJWTSigningKeyTooShort)
+	assert.Equal(t, before, JWTSigningKey())
+}
+
+func TestSetJWTSigningKeyAcceptsMinimumLength(t *testing.T) {
+	secret := bytes.Repeat([]byte("z"), MinJWTSecretKeyBytes)
+	err := SetJWTSigningKey(secret)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, secret, JWTSigningKey())
+	_, err = GenerateToken("user-after-rotate")
+	assert.NoError(t, err)
+	// Restore default for other tests in the package.
+	assert.NoError(t, SetJWTSigningKey(bytes.Repeat([]byte("k"), MinJWTSecretKeyBytes)))
+}
+
+func TestGenerateTokenErrorWhenSigningKeyUnset(t *testing.T) {
+	prev := JWTSigningKey()
+	ClearJWTSigningKeyForTesting()
+	t.Cleanup(func() {
+		assert.NoError(t, SetJWTSigningKey(prev))
+	})
+	_, err := GenerateToken("any")
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrJWTSigningKeyNotConfigured))
 }
 
 func TestJWTKeyFuncRejectsNonHS256Algorithms(t *testing.T) {

--- a/pkg/middleware/authenticateJWT.go
+++ b/pkg/middleware/authenticateJWT.go
@@ -28,10 +28,17 @@ func JWTAuth() gin.HandlerFunc {
 			return
 		}
 
+		signingKey := auth.JWTSigningKey()
+		if len(signingKey) < auth.MinJWTSecretKeyBytes {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "JWT signing key not configured"})
+			c.Abort()
+			return
+		}
+
 		tokenStr := header[len(BearerSchema):]
 		claims := &auth.Claims{}
 
-		token, err := jwt.ParseWithClaims(tokenStr, claims, auth.JWTKeyFunc(auth.JwtKey))
+		token, err := jwt.ParseWithClaims(tokenStr, claims, auth.JWTKeyFunc(signingKey))
 
 		if err != nil {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})

--- a/pkg/middleware/authenticateJWT_test.go
+++ b/pkg/middleware/authenticateJWT_test.go
@@ -1,10 +1,12 @@
 package middleware
 
 import (
+	"bytes"
 	"encoding/json"
 	"golang-rest-api-template/pkg/auth"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -14,6 +16,13 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+func TestMain(m *testing.M) {
+	if err := auth.SetJWTSigningKey(bytes.Repeat([]byte("m"), auth.MinJWTSecretKeyBytes)); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
 func testRouterJWTAuthOnly(t *testing.T) *gin.Engine {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -22,6 +31,24 @@ func testRouterJWTAuthOnly(t *testing.T) *gin.Engine {
 		c.Status(http.StatusOK)
 	})
 	return r
+}
+
+func TestJWTAuthSigningKeyNotConfiguredReturns503(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	auth.ClearJWTSigningKeyForTesting()
+	t.Cleanup(func() {
+		if err := auth.SetJWTSigningKey(prev); err != nil {
+			t.Fatalf("restore jwt key: %v", err)
+		}
+	})
+	r := testRouterJWTAuthOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer irrelevant")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d body=%q", rec.Code, rec.Body.String())
+	}
 }
 
 func TestJWTAuthValidBearer(t *testing.T) {
@@ -75,7 +102,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
-	key := auth.JwtKey
+	key := auth.JWTSigningKey()
 	exp := time.Now().Add(time.Hour)
 	claims := &auth.Claims{
 		Username: "other",


### PR DESCRIPTION
## Summary

Addresses [#91](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/91): **JWT signing secret** is no longer read from the environment at package init. `cmd/server/main` calls \`auth.SetJWTSigningKey\` with \`JWT_SECRET_KEY\` and **exits on error** if the value is missing or shorter than **32 bytes** (\`MinJWTSecretKeyBytes\`).

Runtime state lives behind \`sync.RWMutex\`; \`JWTSigningKey\` returns a **copy** of the secret. \`GenerateToken\` returns \`ErrJWTSigningKeyNotConfigured\` when the key is unset. \`JWTAuth\` returns **503** if the key is not configured before parsing the Bearer token.

Tests use \`TestMain\` in \`pkg/api\`, \`pkg/auth\`, and \`pkg/middleware\` to install a valid test key (replacing the ineffective \`os.Setenv\` in \`user_test.go\`). \`.env.example\` notes the minimum length.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Note:** Deployments with a \`JWT_SECRET_KEY\` shorter than 32 bytes will **fail to start** until the secret is lengthened (e.g. \`go run ./scripts/generate_key.go\`).

## How to test

\`\`\`bash
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [x] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #91

Made with [Cursor](https://cursor.com)