### PR TITLE
fix(security): constant-time API key; startup-loaded secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,5 +20,5 @@ MONGODB_URI=mongodb://localhost:27017
 # Generate with: go run ./scripts/generate_key.go
 JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
-# Shared secret for routes that validate the X-API-Key header
+# Shared secret for X-API-Key (raw string length must be at least 32 bytes).
 API_SECRET_KEY=replace-me-generate-with-scripts-generate-key

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/database"
+	"golang-rest-api-template/pkg/middleware"
 	"log"
 	"os"
 
@@ -42,6 +43,9 @@ import (
 func main() {
 	if err := auth.SetJWTSigningKey([]byte(os.Getenv("JWT_SECRET_KEY"))); err != nil {
 		log.Fatalf("invalid JWT_SECRET_KEY: %v", err)
+	}
+	if err := middleware.SetAPISecretKey([]byte(os.Getenv("API_SECRET_KEY"))); err != nil {
+		log.Fatalf("invalid API_SECRET_KEY: %v", err)
 	}
 
 	redisClient := cache.NewRedisClient()

--- a/pkg/api/book_routes_auth_test.go
+++ b/pkg/api/book_routes_auth_test.go
@@ -34,8 +34,7 @@ func testBookWriteMiddlewareStack(t *testing.T) *gin.Engine {
 }
 
 func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
-	const apiKey = "book-auth-test-api-secret"
-	t.Setenv("API_SECRET_KEY", apiKey)
+	const apiKey = testAPISecretKey
 
 	token, err := auth.GenerateToken("book-writer")
 	if err != nil {
@@ -140,8 +139,7 @@ func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
 }
 
 func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
-	const apiKey = "book-auth-test-api-secret-2"
-	t.Setenv("API_SECRET_KEY", apiKey)
+	const apiKey = testAPISecretKey
 
 	token, err := auth.GenerateToken("u1")
 	if err != nil {
@@ -175,8 +173,7 @@ func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
 }
 
 func TestBookWriteRoutesConcurrentAuthorizedRequests(t *testing.T) {
-	const apiKey = "book-auth-test-api-secret-concurrent"
-	t.Setenv("API_SECRET_KEY", apiKey)
+	const apiKey = testAPISecretKey
 
 	token, err := auth.GenerateToken("concurrent-user")
 	if err != nil {

--- a/pkg/api/main_test.go
+++ b/pkg/api/main_test.go
@@ -6,13 +6,20 @@ import (
 	"testing"
 
 	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/middleware"
 
 	"github.com/gin-gonic/gin"
 )
 
+// testAPISecretKey is the X-API-Key value expected by middleware in tests (32 bytes).
+const testAPISecretKey = "01234567890123456789012345678901"
+
 func TestMain(m *testing.M) {
 	gin.SetMode(gin.TestMode)
 	if err := auth.SetJWTSigningKey(bytes.Repeat([]byte("t"), auth.MinJWTSecretKeyBytes)); err != nil {
+		panic(err)
+	}
+	if err := middleware.SetAPISecretKey([]byte(testAPISecretKey)); err != nil {
 		panic(err)
 	}
 	os.Exit(m.Run())

--- a/pkg/middleware/api_key.go
+++ b/pkg/middleware/api_key.go
@@ -1,22 +1,105 @@
 package middleware
 
 import (
+	"crypto/subtle"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"net/http"
-	"os"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 )
 
+// MinAPISecretKeyBytes is the minimum accepted length for the API shared secret
+// (raw bytes of API_SECRET_KEY).
+const MinAPISecretKeyBytes = 32
+
+var (
+	// ErrAPISecretKeyTooShort is returned by SetAPISecretKey when the secret is
+	// shorter than MinAPISecretKeyBytes.
+	ErrAPISecretKeyTooShort = errors.New("API secret key below minimum length")
+
+	apiSecretMu sync.RWMutex
+	apiSecret   []byte
+)
+
+// SetAPISecretKey configures the expected raw value for the X-API-Key header.
+// It must be called during application startup with a non-empty secret of at
+// least MinAPISecretKeyBytes.
+func SetAPISecretKey(secret []byte) error {
+	if len(secret) < MinAPISecretKeyBytes {
+		return fmt.Errorf("%w: got %d bytes, need at least %d", ErrAPISecretKeyTooShort, len(secret), MinAPISecretKeyBytes)
+	}
+	k := make([]byte, len(secret))
+	copy(k, secret)
+	apiSecretMu.Lock()
+	apiSecret = k
+	apiSecretMu.Unlock()
+	return nil
+}
+
+func apiSecretCopy() []byte {
+	apiSecretMu.RLock()
+	defer apiSecretMu.RUnlock()
+	if len(apiSecret) == 0 {
+		return nil
+	}
+	out := make([]byte, len(apiSecret))
+	copy(out, apiSecret)
+	return out
+}
+
+// ClearAPISecretKeyForTesting removes the configured API secret. Intended only
+// for tests; callers must restore a valid key (for example via t.Cleanup).
+func ClearAPISecretKeyForTesting() {
+	apiSecretMu.Lock()
+	apiSecret = nil
+	apiSecretMu.Unlock()
+}
+
+// constantTimeAPIKeyEqual reports whether provided equals secret using
+// crypto/subtle. Length is folded into the compared buffers so a single
+// ConstantTimeCompare runs for every request.
+func constantTimeAPIKeyEqual(provided string, secret []byte) bool {
+	if len(secret) == 0 {
+		return false
+	}
+	n := len(secret)
+	p := []byte(provided)
+	candidate := make([]byte, n)
+	if len(p) >= n {
+		copy(candidate, p[:n])
+	} else {
+		copy(candidate, p)
+	}
+	var la, lb [8]byte
+	binary.BigEndian.PutUint64(la[:], uint64(len(p)))
+	binary.BigEndian.PutUint64(lb[:], uint64(n))
+	left := append(candidate, la[:]...)
+	right := append(make([]byte, 0, n+8), secret...)
+	right = append(right, lb[:]...)
+	return subtle.ConstantTimeCompare(left, right) == 1
+}
+
+// APIKeyAuth returns Gin middleware that validates the X-API-Key header
+// against the configured secret using a constant-time comparison.
 func APIKeyAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		apiKey := c.GetHeader("X-API-Key")
-		if apiKey == os.Getenv("API_SECRET_KEY") {
-			c.Next()
-		} else {
-			c.JSON(http.StatusUnauthorized, gin.H{
-				"error": "Unauthorized",
-			})
+		secret := apiSecretCopy()
+		if len(secret) < MinAPISecretKeyBytes {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "API secret key not configured"})
 			c.Abort()
+			return
 		}
+		apiKey := c.GetHeader("X-API-Key")
+		if constantTimeAPIKeyEqual(apiKey, secret) {
+			c.Next()
+			return
+		}
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "Unauthorized",
+		})
+		c.Abort()
 	}
 }

--- a/pkg/middleware/api_key_test.go
+++ b/pkg/middleware/api_key_test.go
@@ -1,0 +1,112 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func testRouterAPIKeyOnly(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/k", APIKeyAuth(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	return r
+}
+
+func TestSetAPISecretKeyRejectsShortSecret(t *testing.T) {
+	want := apiSecretCopy()
+	err := SetAPISecretKey(bytes.Repeat([]byte("p"), MinAPISecretKeyBytes-1))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrAPISecretKeyTooShort)
+	assert.Equal(t, want, apiSecretCopy())
+}
+
+func TestAPIKeyAuthValidKey(t *testing.T) {
+	r := testRouterAPIKeyOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/k", nil)
+	req.Header.Set("X-API-Key", strings.Repeat("x", MinAPISecretKeyBytes))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestAPIKeyAuthWrongKey(t *testing.T) {
+	r := testRouterAPIKeyOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/k", nil)
+	req.Header.Set("X-API-Key", strings.Repeat("y", MinAPISecretKeyBytes))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	var body map[string]any
+	assert.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "Unauthorized", body["error"])
+}
+
+func TestAPIKeyAuthWrongLengthRejected(t *testing.T) {
+	r := testRouterAPIKeyOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/k", nil)
+	req.Header.Set("X-API-Key", strings.Repeat("x", MinAPISecretKeyBytes-1))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAPIKeyAuthMissingHeader(t *testing.T) {
+	r := testRouterAPIKeyOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/k", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestAPIKeyAuthSecretNotConfiguredReturns503(t *testing.T) {
+	prev := apiSecretCopy()
+	ClearAPISecretKeyForTesting()
+	t.Cleanup(func() {
+		assert.NoError(t, SetAPISecretKey(prev))
+	})
+	r := testRouterAPIKeyOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/k", nil)
+	req.Header.Set("X-API-Key", strings.Repeat("x", MinAPISecretKeyBytes))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestAPIKeyAuthConcurrentValidRequests(t *testing.T) {
+	r := testRouterAPIKeyOnly(t)
+	const workers = 32
+	key := strings.Repeat("x", MinAPISecretKeyBytes)
+	var wg sync.WaitGroup
+	errs := make(chan string, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/k", nil)
+			req.Header.Set("X-API-Key", key)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				errs <- w.Body.String()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for msg := range errs {
+		if msg != "" {
+			t.Fatalf("unexpected failure body=%q", msg)
+		}
+	}
+}

--- a/pkg/middleware/authenticateJWT_test.go
+++ b/pkg/middleware/authenticateJWT_test.go
@@ -20,6 +20,9 @@ func TestMain(m *testing.M) {
 	if err := auth.SetJWTSigningKey(bytes.Repeat([]byte("m"), auth.MinJWTSecretKeyBytes)); err != nil {
 		panic(err)
 	}
+	if err := SetAPISecretKey(bytes.Repeat([]byte("x"), MinAPISecretKeyBytes)); err != nil {
+		panic(err)
+	}
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Summary

Implements [#92](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/92): **API key** validation no longer uses \`os.Getenv\` per request or plain string \`==\`. \`cmd/server/main\` calls \`middleware.SetAPISecretKey\` with \`API_SECRET_KEY\` and **exits on error** if unset or shorter than **32 bytes** (\`MinAPISecretKeyBytes\`), matching the JWT secret posture.

\`APIKeyAuth\` compares \`X-API-Key\` with \`crypto/subtle.ConstantTimeCompare\` over buffers that include an encoded length suffix so mismatched lengths still perform one comparison. Misconfiguration returns **503**.

\`pkg/api\` tests use a shared \`testAPISecretKey\` (32 bytes) configured in \`TestMain\`; \`t.Setenv("API_SECRET_KEY", ...)\` was removed. \`.env.example\` documents the API secret minimum length.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Note:** Deployments with \`API_SECRET_KEY\` shorter than 32 bytes will **fail to start** until the secret is lengthened.

## How to test

\`\`\`bash
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [x] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #92

Made with [Cursor](https://cursor.com)