### PR TITLE
fix(security): hide User password from JSON (#94)

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -50,17 +50,15 @@ func NewUserRepository(db database.Database, ctx *context.Context) *userReposito
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /login [post]
 func (r *userRepository) LoginHandler(c *gin.Context) {
-	var incomingUser models.User
+	var incoming models.LoginUser
 	var dbUser models.User
 
-	// Get JSON body
-	if err := c.ShouldBindJSON(&incomingUser); err != nil {
+	if err := c.ShouldBindJSON(&incoming); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request"})
 		return
 	}
 
-	// Fetch the user from the database
-	if err := r.DB.Where("username = ?", incomingUser.Username).First(&dbUser).Error(); err != nil {
+	if err := r.DB.Where("username = ?", incoming.Username).First(&dbUser).Error(); err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid username or password"})
 		} else {
@@ -69,8 +67,7 @@ func (r *userRepository) LoginHandler(c *gin.Context) {
 		return
 	}
 
-	// Verify password
-	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(incomingUser.Password)); err != nil {
+	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(incoming.Password)); err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid username or password"})
 		return
 	}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -10,7 +10,7 @@ type LoginUser struct {
 type User struct {
 	ID        uint      `json:"id" gorm:"primary_key"`
 	Username  string    `json:"username" gorm:"unique"`
-	Password  string    `json:"password"`
+	Password  string    `json:"-"`
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`
 	UpdatedAt time.Time `json:"updated_at" gorm:"autoUpdateTime"`
 }

--- a/pkg/models/user_test.go
+++ b/pkg/models/user_test.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestUserJSONOmitsPassword(t *testing.T) {
+	u := User{
+		ID:        1,
+		Username:  "alice",
+		Password:  "bcrypt-digest-must-not-leak",
+		CreatedAt: time.Unix(1000, 0).UTC(),
+		UpdatedAt: time.Unix(2000, 0).UTC(),
+	}
+	b, err := json.Marshal(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["password"]; ok {
+		t.Fatalf("password field must not appear in JSON: %s", string(b))
+	}
+	if m["username"] != "alice" {
+		t.Fatalf("username: got %v", m["username"])
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#94](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/94).

- \`models.User.Password\` now uses \`json:\"-\"\` so \`encoding/json\` never emits the bcrypt digest (future handlers returning \`User\` are safe).
- \`LoginHandler\` binds the request body with \`models.LoginUser\` (which still exposes \`json:\"password\"\`) instead of \`models.User\`, so plaintext credentials continue to bind after the model change.
- \`pkg/models/user_test.go\`: \`TestUserJSONOmitsPassword\` asserts the hash is absent from marshaled JSON.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

\`\`\`bash
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #94

Made with [Cursor](https://cursor.com)