### PR TITLE
fix(security): Gin trusted proxies for ClientIP (#95)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
 # Shared secret for X-API-Key (raw string length must be at least 32 bytes).
 API_SECRET_KEY=replace-me-generate-with-scripts-generate-key
+
+# Optional: comma-separated trusted proxy CIDRs for Gin ClientIP / X-Forwarded-For.
+# Leave unset to trust no proxies (only the direct TCP peer is used).
+# GIN_TRUSTED_PROXIES=127.0.0.0/8,::1/128

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Names below match `os.Getenv` usage in this repository:
 | `REDIS_HOST` | Redis hostname (the app appends `:6379`; see `pkg/cache/cache.go`) |
 | `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
 | `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
+| `GIN_TRUSTED_PROXIES` | Optional comma-separated CIDRs trusted for `X-Forwarded-For` / `ClientIP` (`pkg/api/router.go`). If unset, only the direct peer address is used. |
 
 To generate URL-safe random values for `JWT_SECRET_KEY` and `API_SECRET_KEY`, run:
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -2,10 +2,13 @@ package api
 
 import (
 	"context"
+	"os"
+	"strings"
+	"time"
+
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/database"
 	"golang-rest-api-template/pkg/middleware"
-	"time"
 
 	docs "golang-rest-api-template/docs"
 
@@ -30,6 +33,9 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 	userRepository := NewUserRepository(db, ctx)
 
 	r := gin.Default()
+	if err := configureTrustedProxies(r); err != nil {
+		panic("api: trusted proxies: " + err.Error())
+	}
 	r.Use(middleware.RequestID())
 	r.Use(ContextMiddleware(bookRepository))
 
@@ -58,4 +64,23 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerfiles.Handler))
 
 	return r
+}
+
+// configureTrustedProxies sets which upstreams may influence ClientIP via
+// X-Forwarded-For and related headers. If GIN_TRUSTED_PROXIES is unset or
+// blank, no proxies are trusted (equivalent to SetTrustedProxies(nil)), so
+// ClientIP reflects the direct TCP peer only. Otherwise the value is a
+// comma-separated list of IPs or CIDRs accepted by gin.Engine.SetTrustedProxies.
+func configureTrustedProxies(engine *gin.Engine) error {
+	raw := strings.TrimSpace(os.Getenv("GIN_TRUSTED_PROXIES"))
+	if raw == "" {
+		return engine.SetTrustedProxies(nil)
+	}
+	var list []string
+	for _, p := range strings.Split(raw, ",") {
+		if s := strings.TrimSpace(p); s != "" {
+			list = append(list, s)
+		}
+	}
+	return engine.SetTrustedProxies(list)
 }

--- a/pkg/api/router_trusted_proxies_test.go
+++ b/pkg/api/router_trusted_proxies_test.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureTrustedProxiesNilIgnoresForwardedFor(t *testing.T) {
+	t.Setenv("GIN_TRUSTED_PROXIES", "")
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	if !assert.NoError(t, configureTrustedProxies(r)) {
+		return
+	}
+	r.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.0.2.10:5555"
+	req.Header.Set("X-Forwarded-For", "203.0.113.7")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "192.0.2.10", rec.Body.String())
+}
+
+func TestConfigureTrustedProxiesInvalidEnvReturnsError(t *testing.T) {
+	t.Setenv("GIN_TRUSTED_PROXIES", "not-a-valid-cidr!!!")
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	err := configureTrustedProxies(r)
+	assert.Error(t, err)
+}
+
+func TestConfigureTrustedProxiesAllowsForwardedFromTrustedPeer(t *testing.T) {
+	t.Setenv("GIN_TRUSTED_PROXIES", "192.0.2.10/32")
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	if !assert.NoError(t, configureTrustedProxies(r)) {
+		return
+	}
+	r.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = "192.0.2.10:5555"
+	req.Header.Set("X-Forwarded-For", "198.51.100.22")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "198.51.100.22", rec.Body.String())
+}


### PR DESCRIPTION
## Summary

Closes [#95](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/95).

- \`NewRouter\` now calls \`configureTrustedProxies\` immediately after \`gin.Default()\`.
- **Default:** \`GIN_TRUSTED_PROXIES\` unset or blank → \`SetTrustedProxies(nil)\`, so \`ClientIP\` (used by logging middleware) uses the **direct TCP peer** and ignores spoofed \`X-Forwarded-For\`.
- **Optional:** set \`GIN_TRUSTED_PROXIES\` to a comma-separated list of IPs/CIDRs passed to \`gin.Engine.SetTrustedProxies\` when the app sits behind known reverse proxies or load balancers.
- Invalid values cause \`configureTrustedProxies\` to return an error and \`NewRouter\` panics at startup (fail-fast).
- Tests cover default behavior, invalid env, and a trusted-peer + XFF success path.
- **README** env table and **.env.example** comment updated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [x] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

\`\`\`bash
go test ./pkg/api -run TrustedProxies -v
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [x] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #95

Made with [Cursor](https://cursor.com)