### PR TITLE
fix(security): limit request body size (#96)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ API_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 # Optional: comma-separated trusted proxy CIDRs for Gin ClientIP / X-Forwarded-For.
 # Leave unset to trust no proxies (only the direct TCP peer is used).
 # GIN_TRUSTED_PROXIES=127.0.0.0/8,::1/128
+
+# Optional: max request body size in bytes for POST/PUT/PATCH (default 1048576 = 1 MiB).
+# REQUEST_MAX_BODY_BYTES=2097152

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Names below match `os.Getenv` usage in this repository:
 | `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
 | `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
 | `GIN_TRUSTED_PROXIES` | Optional comma-separated CIDRs trusted for `X-Forwarded-For` / `ClientIP` (`pkg/api/router.go`). If unset, only the direct peer address is used. |
+| `REQUEST_MAX_BODY_BYTES` | Optional cap on JSON/body bytes for `POST`/`PUT`/`PATCH` (default `1048576`, i.e. 1 MiB; `pkg/middleware/max_body.go`). |
 
 To generate URL-safe random values for `JWT_SECRET_KEY` and `API_SECRET_KEY`, run:
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -36,6 +37,7 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 	if err := configureTrustedProxies(r); err != nil {
 		panic("api: trusted proxies: " + err.Error())
 	}
+	r.Use(middleware.MaxRequestBody(maxRequestBodyBytesFromEnv()))
 	r.Use(middleware.RequestID())
 	r.Use(ContextMiddleware(bookRepository))
 
@@ -83,4 +85,18 @@ func configureTrustedProxies(engine *gin.Engine) error {
 		}
 	}
 	return engine.SetTrustedProxies(list)
+}
+
+// maxRequestBodyBytesFromEnv returns REQUEST_MAX_BODY_BYTES or the middleware
+// default (1 MiB). Invalid or non-positive values panic at process startup.
+func maxRequestBodyBytesFromEnv() int64 {
+	s := strings.TrimSpace(os.Getenv("REQUEST_MAX_BODY_BYTES"))
+	if s == "" {
+		return middleware.DefaultMaxRequestBodyBytes
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n <= 0 {
+		panic("api: REQUEST_MAX_BODY_BYTES must be a positive integer (bytes): " + s)
+	}
+	return n
 }

--- a/pkg/middleware/max_body.go
+++ b/pkg/middleware/max_body.go
@@ -1,0 +1,34 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DefaultMaxRequestBodyBytes is used when MaxRequestBody is called with a
+// non-positive limit or when the caller passes zero explicitly.
+const DefaultMaxRequestBodyBytes int64 = 1 << 20 // 1 MiB
+
+// MaxRequestBody returns middleware that caps how many bytes handlers may read
+// from the request body for POST, PUT, and PATCH. Larger bodies yield HTTP 413
+// (via http.MaxBytesReader) without buffering the entire payload in memory.
+func MaxRequestBody(maxBytes int64) gin.HandlerFunc {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxRequestBodyBytes
+	}
+	return func(c *gin.Context) {
+		switch c.Request.Method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch:
+		default:
+			c.Next()
+			return
+		}
+		if c.Request.ContentLength > maxBytes {
+			c.AbortWithStatus(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		c.Next()
+	}
+}

--- a/pkg/middleware/max_body_test.go
+++ b/pkg/middleware/max_body_test.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestMaxRequestBodyAllowsSmallPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	const limit = 1024
+	r.POST("/p", MaxRequestBody(limit), func(c *gin.Context) {
+		_, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodPost, "/p", strings.NewReader(`{"x":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+func TestMaxRequestBodyRejectsOversizedContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	const limit = 100
+	r.POST("/p", MaxRequestBody(limit), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	body := bytes.Repeat([]byte("a"), limit+1)
+	req := httptest.NewRequest(http.MethodPost, "/p", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = int64(len(body))
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("want 413, got %d", rec.Code)
+	}
+}
+
+func TestMaxRequestBodyMaxBytesReaderWithoutContentLength(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	const limit = 64
+	r.POST("/p", MaxRequestBody(limit), func(c *gin.Context) {
+		_, err := io.Copy(io.Discard, c.Request.Body)
+		if err != nil {
+			c.AbortWithStatus(http.StatusRequestEntityTooLarge)
+			return
+		}
+		c.Status(http.StatusOK)
+	})
+	// ContentLength -1: reader still capped
+	req := httptest.NewRequest(http.MethodPost, "/p", bytes.NewReader(bytes.Repeat([]byte("b"), limit+10)))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("want 413, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Closes [#96](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/96).

- New \`middleware.MaxRequestBody\` wraps \`c.Request.Body\` with \`http.MaxBytesReader\` for **POST**, **PUT**, and **PATCH** so oversized payloads cannot exhaust memory.
- Rejects **Content-Length** greater than the limit with **413** before reading the body.
- \`NewRouter\` registers this middleware early (after trusted proxies). Default limit is **1 MiB** (\`middleware.DefaultMaxRequestBodyBytes\`).
- Optional \`REQUEST_MAX_BODY_BYTES\` (positive integer); invalid values **panic at startup**.
- Table-driven style tests in \`max_body_test.go\`; README and \`.env.example\` updated.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [x] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

\`\`\`bash
go test ./pkg/middleware -run MaxRequestBody -v
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [x] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #96

Made with [Cursor](https://cursor.com)