### PR TITLE
fix(ops): Redis env — password, TLS, timeouts, port (#97)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,18 @@ POSTGRES_USER=docker
 POSTGRES_PASSWORD=replace-me
 POSTGRES_PORT=5435
 
+# Redis: use REDIS_ADDR=host:port OR set REDIS_HOST and optional REDIS_PORT (default 6379).
 REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_ADDR=
+# REDIS_PASSWORD=
+# REDIS_USERNAME=
+# REDIS_DB=0
+# REDIS_TLS=false
+# REDIS_TLS_INSECURE=false
+# REDIS_DIAL_TIMEOUT=5s
+# REDIS_READ_TIMEOUT=3s
+# REDIS_WRITE_TIMEOUT=3s
 
 # MongoDB connection string (use mongodb://mongo:27017 when the API runs inside Compose)
 MONGODB_URI=mongodb://localhost:27017

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Names below match `os.Getenv` usage in this repository:
 | `REDIS_PASSWORD` | Redis `AUTH` password (optional) |
 | `REDIS_USERNAME` | Redis ACL username (optional; Redis 6+) |
 | `REDIS_DB` | Logical database index (default `0`) |
-| `REDIS_TLS` | Set `true` / `1` / `yes` to use TLS (`MinVersion` TLS 1.2) |
-| `REDIS_TLS_INSECURE` | Set `true` / `1` / `yes` to skip server certificate verification (dev only) |
+| `REDIS_TLS` | Set `true` / `1` / `yes` / `on` to use TLS (`MinVersion` TLS 1.2) |
+| `REDIS_TLS_INSECURE` | Set `true` / `1` / `yes` / `on` to skip server certificate verification (**never in production**) |
 | `REDIS_DIAL_TIMEOUT` | Dial timeout (Go duration, default `5s`) |
 | `REDIS_READ_TIMEOUT` | Read timeout (default `3s`) |
 | `REDIS_WRITE_TIMEOUT` | Write timeout (default `3s`) |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,17 @@ Names below match `os.Getenv` usage in this repository:
 | `POSTGRES_USER` | Database user |
 | `POSTGRES_PASSWORD` | Database password |
 | `POSTGRES_PORT` | PostgreSQL port |
-| `REDIS_HOST` | Redis hostname (the app appends `:6379`; see `pkg/cache/cache.go`) |
+| `REDIS_ADDR` | Optional full `host:port` for Redis; when set, overrides `REDIS_HOST` / `REDIS_PORT` (`pkg/cache/cache.go`) |
+| `REDIS_HOST` | Redis hostname when `REDIS_ADDR` is unset (default `127.0.0.1`) |
+| `REDIS_PORT` | Redis TCP port when `REDIS_ADDR` is unset (default `6379`) |
+| `REDIS_PASSWORD` | Redis `AUTH` password (optional) |
+| `REDIS_USERNAME` | Redis ACL username (optional; Redis 6+) |
+| `REDIS_DB` | Logical database index (default `0`) |
+| `REDIS_TLS` | Set `true` / `1` / `yes` to use TLS (`MinVersion` TLS 1.2) |
+| `REDIS_TLS_INSECURE` | Set `true` / `1` / `yes` to skip server certificate verification (dev only) |
+| `REDIS_DIAL_TIMEOUT` | Dial timeout (Go duration, default `5s`) |
+| `REDIS_READ_TIMEOUT` | Read timeout (default `3s`) |
+| `REDIS_WRITE_TIMEOUT` | Write timeout (default `3s`) |
 | `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
 | `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
 | `GIN_TRUSTED_PROXIES` | Optional comma-separated CIDRs trusted for `X-Forwarded-For` / `ClientIP` (`pkg/api/router.go`). If unset, only the direct peer address is used. |

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -48,7 +48,10 @@ func main() {
 		log.Fatalf("invalid API_SECRET_KEY: %v", err)
 	}
 
-	redisClient := cache.NewRedisClient()
+	redisClient, err := cache.NewRedisClient()
+	if err != nil {
+		log.Fatalf("redis: %v", err)
+	}
 	db := database.NewDatabase()
 	dbWrapper := &database.GormDatabase{DB: db}
 	mongo := database.SetupMongoDB()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,7 +2,11 @@ package cache
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -15,10 +19,90 @@ type Cache interface {
 	Del(context.Context, ...string) *redis.IntCmd
 }
 
-func NewRedisClient() *redis.Client {
-	return redis.NewClient(&redis.Options{
-		Addr:     os.Getenv("REDIS_HOST") + ":6379", // Redis server address (change to localhost when running local)
-		Password: "",                                // Password, leave empty if none
-		DB:       0,                                 // Default DB
-	})
+// NewRedisClient builds a go-redis client from environment variables.
+// See redisOptionsFromEnv for supported keys and defaults.
+func NewRedisClient() (*redis.Client, error) {
+	opts, err := redisOptionsFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return redis.NewClient(opts), nil
+}
+
+func redisOptionsFromEnv() (*redis.Options, error) {
+	opts := &redis.Options{
+		Password: strings.TrimSpace(os.Getenv("REDIS_PASSWORD")),
+	}
+
+	if u := strings.TrimSpace(os.Getenv("REDIS_USERNAME")); u != "" {
+		opts.Username = u
+	}
+
+	addr := strings.TrimSpace(os.Getenv("REDIS_ADDR"))
+	if addr != "" {
+		opts.Addr = addr
+	} else {
+		host := strings.TrimSpace(os.Getenv("REDIS_HOST"))
+		if host == "" {
+			host = "127.0.0.1"
+		}
+		port := strings.TrimSpace(os.Getenv("REDIS_PORT"))
+		if port == "" {
+			port = "6379"
+		}
+		opts.Addr = host + ":" + port
+	}
+
+	if s := strings.TrimSpace(os.Getenv("REDIS_DB")); s != "" {
+		db, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, fmt.Errorf("REDIS_DB: %w", err)
+		}
+		if db < 0 {
+			return nil, fmt.Errorf("REDIS_DB must be >= 0, got %d", db)
+		}
+		opts.DB = db
+	}
+
+	dial, err := durationFromEnv("REDIS_DIAL_TIMEOUT", 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	read, err := durationFromEnv("REDIS_READ_TIMEOUT", 3*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	write, err := durationFromEnv("REDIS_WRITE_TIMEOUT", 3*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	opts.DialTimeout = dial
+	opts.ReadTimeout = read
+	opts.WriteTimeout = write
+
+	tlsVal := strings.ToLower(strings.TrimSpace(os.Getenv("REDIS_TLS")))
+	if tlsVal == "1" || tlsVal == "true" || tlsVal == "yes" {
+		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
+		if insecure := strings.ToLower(strings.TrimSpace(os.Getenv("REDIS_TLS_INSECURE"))); insecure == "1" || insecure == "true" || insecure == "yes" {
+			cfg.InsecureSkipVerify = true
+		}
+		opts.TLSConfig = cfg
+	}
+
+	return opts, nil
+}
+
+func durationFromEnv(key string, defaultVal time.Duration) (time.Duration, error) {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return defaultVal, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a Go duration (e.g. 5s): %w", key, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("%s must be positive, got %s", key, v)
+	}
+	return d, nil
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -80,16 +80,27 @@ func redisOptionsFromEnv() (*redis.Options, error) {
 	opts.ReadTimeout = read
 	opts.WriteTimeout = write
 
-	tlsVal := strings.ToLower(strings.TrimSpace(os.Getenv("REDIS_TLS")))
-	if tlsVal == "1" || tlsVal == "true" || tlsVal == "yes" {
+	if envTruthy("REDIS_TLS") {
 		cfg := &tls.Config{MinVersion: tls.VersionTLS12}
-		if insecure := strings.ToLower(strings.TrimSpace(os.Getenv("REDIS_TLS_INSECURE"))); insecure == "1" || insecure == "true" || insecure == "yes" {
-			cfg.InsecureSkipVerify = true
+		if envTruthy("REDIS_TLS_INSECURE") {
+			// Development only (e.g. self-signed certs). Do not set in production.
+			cfg.InsecureSkipVerify = true // #nosec G402 -- REDIS_TLS_INSECURE explicit opt-in for non-prod TLS
 		}
 		opts.TLSConfig = cfg
 	}
 
 	return opts, nil
+}
+
+// envTruthy reports whether the named environment variable is set to a
+// conventional affirmative value (1, true, yes, on), case-insensitive.
+func envTruthy(key string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func durationFromEnv(key string, defaultVal time.Duration) (time.Duration, error) {

--- a/pkg/cache/redis_env_test.go
+++ b/pkg/cache/redis_env_test.go
@@ -1,0 +1,130 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisOptionsFromEnvDefaults(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "")
+	t.Setenv("REDIS_HOST", "")
+	t.Setenv("REDIS_PORT", "")
+	t.Setenv("REDIS_DB", "")
+	t.Setenv("REDIS_PASSWORD", "")
+	t.Setenv("REDIS_DIAL_TIMEOUT", "")
+	t.Setenv("REDIS_READ_TIMEOUT", "")
+	t.Setenv("REDIS_WRITE_TIMEOUT", "")
+	t.Setenv("REDIS_TLS", "")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "127.0.0.1:6379", o.Addr)
+	assert.Equal(t, 0, o.DB)
+	assert.Equal(t, 5*time.Second, o.DialTimeout)
+	assert.Equal(t, 3*time.Second, o.ReadTimeout)
+	assert.Equal(t, 3*time.Second, o.WriteTimeout)
+	assert.Nil(t, o.TLSConfig)
+}
+
+func TestRedisOptionsFromEnvAddrOverridesHostPort(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "redis.internal:6380")
+	t.Setenv("REDIS_HOST", "should-not-matter")
+	t.Setenv("REDIS_PORT", "9999")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "redis.internal:6380", o.Addr)
+}
+
+func TestRedisOptionsFromEnvHostAndPort(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "")
+	t.Setenv("REDIS_HOST", "10.0.0.5")
+	t.Setenv("REDIS_PORT", "16379")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "10.0.0.5:16379", o.Addr)
+}
+
+func TestRedisOptionsFromEnvPasswordAndDB(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_PASSWORD", "secret")
+	t.Setenv("REDIS_DB", "2")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "secret", o.Password)
+	assert.Equal(t, 2, o.DB)
+}
+
+func TestRedisOptionsFromEnvInvalidDB(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_DB", "x")
+
+	_, err := redisOptionsFromEnv()
+	assert.Error(t, err)
+}
+
+func TestRedisOptionsFromEnvNegativeDB(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_DB", "-1")
+
+	_, err := redisOptionsFromEnv()
+	assert.Error(t, err)
+}
+
+func TestRedisOptionsFromEnvTLSEnabled(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_TLS", "true")
+	t.Setenv("REDIS_TLS_INSECURE", "")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.NotNil(t, o.TLSConfig) {
+		return
+	}
+	assert.False(t, o.TLSConfig.InsecureSkipVerify)
+}
+
+func TestRedisOptionsFromEnvTLSInsecure(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_TLS", "1")
+	t.Setenv("REDIS_TLS_INSECURE", "true")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.NotNil(t, o.TLSConfig) {
+		return
+	}
+	assert.True(t, o.TLSConfig.InsecureSkipVerify)
+}
+
+func TestRedisOptionsFromEnvInvalidDialTimeout(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_DIAL_TIMEOUT", "nope")
+
+	_, err := redisOptionsFromEnv()
+	assert.Error(t, err)
+}
+
+func TestRedisOptionsFromEnvNonPositiveDialTimeout(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_DIAL_TIMEOUT", "0s")
+
+	_, err := redisOptionsFromEnv()
+	assert.Error(t, err)
+}

--- a/pkg/cache/redis_env_test.go
+++ b/pkg/cache/redis_env_test.go
@@ -113,6 +113,21 @@ func TestRedisOptionsFromEnvTLSInsecure(t *testing.T) {
 	assert.True(t, o.TLSConfig.InsecureSkipVerify)
 }
 
+func TestRedisOptionsFromEnvTruthyTLSOn(t *testing.T) {
+	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
+	t.Setenv("REDIS_TLS", "on")
+	t.Setenv("REDIS_TLS_INSECURE", "")
+
+	o, err := redisOptionsFromEnv()
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.NotNil(t, o.TLSConfig) {
+		return
+	}
+	assert.False(t, o.TLSConfig.InsecureSkipVerify)
+}
+
 func TestRedisOptionsFromEnvInvalidDialTimeout(t *testing.T) {
 	t.Setenv("REDIS_ADDR", "127.0.0.1:6379")
 	t.Setenv("REDIS_DIAL_TIMEOUT", "nope")


### PR DESCRIPTION
## Summary

Closes [#97](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/97).

- **Address:** \`REDIS_ADDR\` (\`host:port\`) **or** \`REDIS_HOST\` + optional \`REDIS_PORT\` (defaults \`127.0.0.1:6379\` when unset).
- **Auth:** \`REDIS_PASSWORD\`, optional \`REDIS_USERNAME\` (Redis 6 ACL).
- **DB:** \`REDIS_DB\` (non-negative integer; default \`0\`).
- **TLS:** \`REDIS_TLS\` \`true\`/\`1\`/\`yes\` enables TLS 1.2+; optional \`REDIS_TLS_INSECURE\` for dev (skips cert verify).
- **Timeouts:** \`REDIS_DIAL_TIMEOUT\`, \`REDIS_READ_TIMEOUT\`, \`REDIS_WRITE_TIMEOUT\` as Go durations (defaults \`5s\` / \`3s\` / \`3s\`).
- \`NewRedisClient\` now returns \`(*redis.Client, error)\`; \`main\` uses \`log.Fatalf\` on error.
- **README** env table and **.env.example** comments updated.
- **\`pkg/cache/redis_env_test.go\`** covers defaults, \`REDIS_ADDR\` override, host/port, password/DB, invalid DB, TLS, invalid/non-positive dial timeout.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (describe impact below)
- [x] Documentation only
- [x] Build / CI / tooling
- [ ] Dependency update

**Breaking:** \`cache.NewRedisClient()\` signature is now \`(*redis.Client, error)\`.

## How to test

\`\`\`bash
go test ./pkg/cache -race -v
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [x] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [ ] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #97

Made with [Cursor](https://cursor.com)