### PR TITLE
fix(security): respect GIN_MODE; release in Docker (#98)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 # Shared secret for X-API-Key (raw string length must be at least 32 bytes).
 API_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
+# Gin: debug (default if unset), release (enables Security + XSS middleware), or test.
+# GIN_MODE=release
+
 # Optional: comma-separated trusted proxy CIDRs for Gin ClientIP / X-Forwarded-For.
 # Leave unset to trust no proxies (only the direct TCP peer is used).
 # GIN_TRUSTED_PROXIES=127.0.0.0/8,::1/128

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN useradd --system --no-create-home --uid 10001 appuser
 
 COPY --from=builder /out/server /app/server
 
+# Default container image to Gin release mode (Security/XSS middleware in router).
+ENV GIN_MODE=release
+
 USER appuser
 
 EXPOSE 8080

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build-docker:
 	docker compose build --no-cache
 
 # Run API against local Docker DBs. Requires `.env` with JWT_SECRET_KEY and API_SECRET_KEY (see .env.example).
+# Optional: set GIN_MODE=release in `.env` for the same security middleware as Docker Compose.
 run-local:
 	docker start dockerPostgres
 	docker start dockerRedis

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Names below match `os.Getenv` usage in this repository:
 | `REDIS_WRITE_TIMEOUT` | Write timeout (default `3s`) |
 | `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
 | `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
+| `GIN_MODE` | Standard Gin variable: `debug` (default if unset), `release` (enables Security + XSS middleware in `pkg/api/router.go`), or `test` |
 | `GIN_TRUSTED_PROXIES` | Optional comma-separated CIDRs trusted for `X-Forwarded-For` / `ClientIP` (`pkg/api/router.go`). If unset, only the direct peer address is used. |
 | `REQUEST_MAX_BODY_BYTES` | Optional cap on JSON/body bytes for `POST`/`PUT`/`PATCH` (default `1048576`, i.e. 1 MiB; `pkg/middleware/max_body.go`). |
 
@@ -138,7 +139,7 @@ To generate URL-safe random values for `JWT_SECRET_KEY` and `API_SECRET_KEY`, ru
 go run ./scripts/generate_key.go
 ```
 
-`docker-compose.yml` does **not** embed JWT or API secrets; they must come from `.env` or your shell environment so keys are not committed to the repository.
+`docker-compose.yml` does **not** embed JWT or API secrets; they must come from `.env` or your shell environment so keys are not committed to the repository. The Compose file sets **`GIN_MODE=release`** for the API service so production-style security headers apply; override in `.env` if you need `debug` locally.
 
 ### API Documentation
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,8 +11,6 @@ import (
 	"os"
 
 	"go.uber.org/zap"
-
-	"github.com/gin-gonic/gin"
 )
 
 // @title           Swagger Example API
@@ -59,8 +57,9 @@ func main() {
 	logger, _ := zap.NewProduction()
 	defer logger.Sync()
 
-	//gin.SetMode(gin.ReleaseMode)
-	gin.SetMode(gin.DebugMode)
+	// Gin mode comes from GIN_MODE (debug | release | test); see gin.EnvGinMode.
+	// Gin's init already applied os.Getenv("GIN_MODE"); do not override here.
+	// Use GIN_MODE=release in production so Security/XSS middleware run (pkg/api/router.go).
 
 	r := api.NewRouter(logger, mongo, dbWrapper, redisClient, &ctx)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       API_SECRET_KEY: ${API_SECRET_KEY:?API_SECRET_KEY must be set - copy .env.example to .env and fill secrets}
       REDIS_HOST: redis
       MONGODB_URI: mongodb://mongo:27017
+      # Enables HSTS/CSP and XSS middleware in pkg/api/router.go (Gin release mode).
+      GIN_MODE: release
 
   db:
     image: postgres:14.1-alpine


### PR DESCRIPTION
## Summary

Closes [#98](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/98).

- **\`cmd/server/main.go\`**: Removed unconditional \`gin.SetMode(gin.DebugMode)\`. Gin already reads \`GIN_MODE\` in package \`init\` (\`gin.EnvGinMode\`); when unset, Gin defaults to **debug** for local \`go run\`.
- **\`docker-compose.yml\`**: Set \`GIN_MODE=release\` on the backend service so \`Security()\` and \`Xss()\` run in \`pkg/api/router.go\`.
- **\`Dockerfile\`**: \`ENV GIN_MODE=release\` on the runtime image so containers match production unless overridden.
- **README**, **.env.example**, **Makefile**: Document \`GIN_MODE\` and the Compose default.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [x] Documentation only
- [x] Build / CI / tooling
- [ ] Dependency update

## How to test

\`\`\`bash
go build -o /tmp/api ./cmd/server/main.go
go test ./... -race
\`\`\`

## Checklist

- [x] \`go test ./... -race\` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (\`swag init\` / project \`Makefile\` \`setup\` target) and \`docs/\` is updated if required
- [x] If you added or renamed **environment variables**: README and/or \`.env\` examples are updated
- [x] If you changed **Docker or compose**: \`docker compose build\` (or \`make build-docker\`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #98

Made with [Cursor](https://cursor.com)