### PR TITLE
fix(api): DELETE book returns 204 with no body (#99)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -275,10 +275,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "Successfully deleted book",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "description": "Successfully deleted book"
                     },
                     "401": {
                         "description": "Unauthorized",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -269,10 +269,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "Successfully deleted book",
-                        "schema": {
-                            "type": "string"
-                        }
+                        "description": "Successfully deleted book"
                     },
                     "401": {
                         "description": "Unauthorized",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -146,8 +146,6 @@ paths:
       responses:
         "204":
           description: Successfully deleted book
-          schema:
-            type: string
         "401":
           description: Unauthorized
           schema:

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -249,7 +249,7 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 // @Security JwtAuth
 // @Produce json
 // @Param id path string true "Book ID"
-// @Success 204 {string} string "Successfully deleted book"
+// @Success 204 "Successfully deleted book"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {string} string "book not found"
 // @Router /books/{id} [delete]
@@ -268,5 +268,5 @@ func (r *bookRepository) DeleteBook(c *gin.Context) {
 
 	r.DB.Delete(&book)
 
-	c.JSON(http.StatusNoContent, gin.H{"data": true})
+	c.Status(http.StatusNoContent)
 }

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -588,6 +588,6 @@ func TestDeleteBook(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodDelete, "/book/1", nil)
 	r.ServeHTTP(w, req)
 
-	// Assert the response
 	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.Empty(t, w.Body.Bytes())
 }


### PR DESCRIPTION
## Summary

DELETE `/books/{id}` previously used `c.JSON(http.StatusNoContent, ...)`, which sends a JSON body. RFC 9110 requires that 204 responses must not include a message body. The handler now calls `c.Status(http.StatusNoContent)` only.

Swagger was regenerated so the 204 response is documented without a schema. `TestDeleteBook` now asserts an empty response body.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change note:** Clients that parsed JSON from a successful DELETE (non-compliant) will no longer receive a body. Status code remains 204.

## How to test

```bash
go test ./... -race
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #99

Made with [Cursor](https://cursor.com)