### PR TITLE
fix(api): propagate GORM errors in book handlers (#100)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -87,6 +87,12 @@ const docTemplate = `{
                                 "$ref": "#/definitions/models.Book"
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -136,6 +142,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -244,6 +256,12 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -285,6 +303,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "book not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -81,6 +81,12 @@
                                 "$ref": "#/definitions/models.Book"
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -130,6 +136,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }
@@ -238,6 +250,12 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             },
@@ -279,6 +297,12 @@
                     },
                     "404": {
                         "description": "book not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "string"
                         }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -95,6 +95,10 @@ paths:
             items:
               $ref: '#/definitions/models.Book'
             type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       security:
       - ApiKeyAuth: []
       summary: Get all books with pagination
@@ -126,6 +130,10 @@ paths:
           description: Unauthorized
           schema:
             type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       security:
       - ApiKeyAuth: []
       - JwtAuth: []
@@ -152,6 +160,10 @@ paths:
             type: string
         "404":
           description: book not found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
           schema:
             type: string
       security:
@@ -217,6 +229,10 @@ paths:
             type: string
         "404":
           description: book not found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
           schema:
             type: string
       security:

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -75,6 +75,7 @@ func (r *bookRepository) Healthcheck(c *gin.Context) {
 // @Param offset query int false "Offset for pagination" default(0)
 // @Param limit query int false "Limit for pagination" default(10)
 // @Success 200 {array} models.Book "Successfully retrieved list of books"
+// @Failure 500 {string} string "Internal Server Error"
 // @Router /books [get]
 func (r *bookRepository) FindBooks(c *gin.Context) {
 	var books []models.Book
@@ -112,7 +113,10 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 	}
 
 	// If cache missed, fetch data from the database
-	r.DB.Offset(offset).Limit(limit).Find(&books)
+	if err := r.DB.Offset(offset).Limit(limit).Find(&books).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
+		return
+	}
 
 	// Serialize books object and store it in Redis
 	serializedBooks, err := json.Marshal(books)
@@ -141,6 +145,7 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 // @Success 201 {object} models.Book "Successfully created book"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
+// @Failure 500 {string} string "Internal Server Error"
 // @Router /books [post]
 func (r *bookRepository) CreateBook(c *gin.Context) {
 	appCtxInterface, exists := c.Get("appCtx")
@@ -162,7 +167,10 @@ func (r *bookRepository) CreateBook(c *gin.Context) {
 
 	book := models.Book{Title: input.Title, Author: input.Author}
 
-	appCtx.DB.Create(&book)
+	if err := appCtx.DB.Create(&book).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book"})
+		return
+	}
 
 	// Invalidate cache
 	keysPattern := "books_offset_*"
@@ -216,6 +224,7 @@ func (r *bookRepository) FindBook(c *gin.Context) {
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {string} string "book not found"
+// @Failure 500 {string} string "Internal Server Error"
 // @Router /books/{id} [put]
 func (r *bookRepository) UpdateBook(c *gin.Context) {
 	var book models.Book
@@ -236,7 +245,10 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 		return
 	}
 
-	r.DB.Model(&book).Updates(models.Book{Title: input.Title, Author: input.Author})
+	if err := r.DB.Model(&book).Updates(models.Book{Title: input.Title, Author: input.Author}).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update book"})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{"data": book})
 }
@@ -252,6 +264,7 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 // @Success 204 "Successfully deleted book"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 404 {string} string "book not found"
+// @Failure 500 {string} string "Internal Server Error"
 // @Router /books/{id} [delete]
 func (r *bookRepository) DeleteBook(c *gin.Context) {
 	var book models.Book
@@ -266,7 +279,10 @@ func (r *bookRepository) DeleteBook(c *gin.Context) {
 		return
 	}
 
-	r.DB.Delete(&book)
+	if err := r.DB.Delete(&book).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete book"})
+		return
+	}
 
 	c.Status(http.StatusNoContent)
 }

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
 )
 
 func TestNewBookRepository(t *testing.T) {
@@ -107,6 +108,43 @@ func TestFindBooksInvalidLimit(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "Invalid limit format")
+}
+
+func TestCreateBookDatabaseError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database.NewMockDatabase(ctrl)
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(mockDB, mockCache, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.POST("/books", func(c *gin.Context) {
+		c.Set("appCtx", repo)
+		repo.CreateBook(c)
+	})
+
+	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
+	requestBody, err := json.Marshal(inputBook)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dbErr := errors.New("db create failed")
+	mockDB.EXPECT().Create(gomock.Any()).Return(&gorm.DB{Error: dbErr})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to create book")
 }
 
 func TestCreateBookBindError(t *testing.T) {
@@ -311,6 +349,91 @@ func TestUpdateBookBindError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "error")
+}
+
+func TestFindBooksDatabaseError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sqlDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlDB.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := sqlDB.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	gdb := &database.GormDatabase{DB: sqlDB}
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(gdb, mockCache, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/books", repo.FindBooks)
+
+	mockCache.EXPECT().Get(ctx, "books_offset_0_limit_10").Return(redis.NewStringResult("", redis.Nil))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/books?offset=0&limit=10", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to list books")
+}
+
+func TestUpdateBookDatabaseErrorOnUpdates(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+
+	existingBook := models.Book{Title: "Old Title", Author: "Old Author"}
+	if err := db.Create(&existingBook).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Exec(`
+		CREATE TRIGGER tr_books_abort_update
+		BEFORE UPDATE ON books
+		BEGIN
+			SELECT RAISE(ABORT, 'forced update failure');
+		END
+	`).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, nil, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.PUT("/book/:id", repo.UpdateBook)
+
+	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
+	requestBody, err := json.Marshal(updateInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/book/1", bytes.NewBuffer(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to update book")
 }
 
 func TestDeleteBookInvalidID(t *testing.T) {
@@ -580,8 +703,7 @@ func TestDeleteBook(t *testing.T) {
 		Delete(&existingBook).
 		Return(&gorm.DB{Error: nil}).Times(1)
 
-	// Mock Error method to return nil
-	mockDB.EXPECT().Error().Return(nil).AnyTimes()
+	mockDB.EXPECT().Error().Return(nil).Times(1)
 
 	// Perform the DELETE request
 	w := httptest.NewRecorder()
@@ -590,4 +712,45 @@ func TestDeleteBook(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.Empty(t, w.Body.Bytes())
+}
+
+func TestDeleteBookDatabaseErrorOnDelete(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database.NewMockDatabase(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(mockDB, nil, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.DELETE("/book/:id", repo.DeleteBook)
+
+	existingBook := models.Book{
+		ID:     1,
+		Title:  "Test Book",
+		Author: "Test Author",
+	}
+
+	mockDB.EXPECT().
+		FirstByID(gomock.Any(), uint(1)).
+		DoAndReturn(func(dest interface{}, id uint) database.Database {
+			if b, ok := dest.(*models.Book); ok {
+				*b = existingBook
+			}
+			return mockDB
+		}).Times(1)
+	mockDB.EXPECT().Error().Return(nil).Times(1)
+
+	delErr := errors.New("delete failed")
+	mockDB.EXPECT().
+		Delete(&existingBook).
+		Return(&gorm.DB{Error: delErr}).Times(1)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/book/1", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Failed to delete book")
 }


### PR DESCRIPTION
## Summary

Book handlers previously ignored errors from `Find`, `Create`, `Updates`, and `Delete` on `*gorm.DB`. They now check the returned `Error` and respond with **500** and a short JSON message. `CreateBook` skips cache invalidation when create fails.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated and `docs/` is updated
- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #100

Made with [Cursor](https://cursor.com)