### PR TITLE
perf(api): FindBooks singleflight for cache stampede (#101)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -54,7 +54,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get a list of all books with optional pagination",
+                "description": "Get a list of all books with optional pagination. Concurrent cache misses for the same offset/limit are coalesced (singleflight) so only one database read and Redis write runs per cache key.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -48,7 +48,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get a list of all books with optional pagination",
+                "description": "Get a list of all books with optional pagination. Concurrent cache misses for the same offset/limit are coalesced (singleflight) so only one database read and Redis write runs per cache key.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,7 +74,9 @@ paths:
       - example
   /books:
     get:
-      description: Get a list of all books with optional pagination
+      description: Get a list of all books with optional pagination. Concurrent cache
+        misses for the same offset/limit are coalesced (singleflight) so only one
+        database read and Redis write runs per cache key.
       parameters:
       - default: 0
         description: Offset for pagination

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	go.mongodb.org/mongo-driver v1.17.9
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.50.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/driver/sqlite v1.6.0
@@ -79,7 +80,6 @@ require (
 	golang.org/x/arch v0.23.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/database"
 	"golang-rest-api-template/pkg/models"
@@ -11,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/singleflight"
 )
 
 type BookRepository interface {
@@ -35,11 +38,19 @@ func parseIDParam(c *gin.Context) (uint, bool) {
 	return uint(id), true
 }
 
+// Sentinel errors for FindBooks singleflight so callers can map failures to HTTP responses.
+var (
+	errListBooksSFDB      = errors.New("listBooks singleflight: database")
+	errListBooksSFMarshal = errors.New("listBooks singleflight: marshal")
+	errListBooksSFRedis   = errors.New("listBooks singleflight: redis set")
+)
+
 // bookRepository holds shared resources like database and Redis client
 type bookRepository struct {
 	DB          database.Database
 	RedisClient cache.Cache
 	Ctx         *context.Context
+	listBooksSF singleflight.Group
 }
 
 // NewAppContext creates a new AppContext
@@ -68,7 +79,7 @@ func (r *bookRepository) Healthcheck(c *gin.Context) {
 
 // FindBooks godoc
 // @Summary Get all books with pagination
-// @Description Get a list of all books with optional pagination
+// @Description Get a list of all books with optional pagination. Concurrent cache misses for the same offset/limit are coalesced (singleflight) so only one database read and Redis write runs per cache key.
 // @Tags books
 // @Security ApiKeyAuth
 // @Produce json
@@ -97,8 +108,8 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 		return
 	}
 
-	// Create a cache key based on query params
-	cacheKey := "books_offset_" + offsetQuery + "_limit_" + limitQuery
+	// Normalized cache key so equivalent pagination (e.g. "0" vs "00") shares one entry and singleflight.
+	cacheKey := fmt.Sprintf("books_offset_%d_limit_%d", offset, limit)
 
 	// Try fetching the data from Redis first
 	cachedBooks, err := r.RedisClient.Get(*r.Ctx, cacheKey).Result()
@@ -112,24 +123,36 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 		return
 	}
 
-	// If cache missed, fetch data from the database
-	if err := r.DB.Offset(offset).Limit(limit).Find(&books).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
+	// If cache missed, coalesce concurrent loads on the same cache key (cache stampede protection).
+	out, err, _ := r.listBooksSF.Do(cacheKey, func() (interface{}, error) {
+		var loaded []models.Book
+		if err := r.DB.Offset(offset).Limit(limit).Find(&loaded).Error; err != nil {
+			return nil, fmt.Errorf("%w: %v", errListBooksSFDB, err)
+		}
+		serializedBooks, err := json.Marshal(loaded)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", errListBooksSFMarshal, err)
+		}
+		if err := r.RedisClient.Set(*r.Ctx, cacheKey, serializedBooks, time.Minute).Err(); err != nil {
+			return nil, fmt.Errorf("%w: %v", errListBooksSFRedis, err)
+		}
+		return loaded, nil
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, errListBooksSFDB):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
+		case errors.Is(err, errListBooksSFMarshal):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal data"})
+		case errors.Is(err, errListBooksSFRedis):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set cache"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
+		}
 		return
 	}
 
-	// Serialize books object and store it in Redis
-	serializedBooks, err := json.Marshal(books)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal data"})
-		return
-	}
-	err = r.RedisClient.Set(*r.Ctx, cacheKey, serializedBooks, time.Minute).Err() // Here TTL is set to one hour
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set cache"})
-		return
-	}
-
+	books = out.([]models.Book)
 	c.JSON(http.StatusOK, gin.H{"data": books})
 }
 

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -10,7 +10,11 @@ import (
 	"golang-rest-api-template/pkg/models"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -753,4 +757,93 @@ func TestDeleteBookDatabaseErrorOnDelete(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), "Failed to delete book")
+}
+
+func TestFindBooksSingleflightCoalescesDB(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "singleflight.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Book{Title: "Coalesced", Author: "Author"}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	const cbName = "pkg/api:test_find_books_sf_counter"
+	var selectN atomic.Int32
+	if err := db.Callback().Query().After("gorm:query").Register(cbName, func(*gorm.DB) {
+		selectN.Add(1)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Callback().Query().Remove(cbName) })
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+
+	const n = 50
+	cacheKey := "books_offset_0_limit_10"
+	var cacheMu sync.Mutex
+	var cachedPayload string
+	mockCache.EXPECT().Get(ctx, cacheKey).DoAndReturn(func(context.Context, string) *redis.StringCmd {
+		cacheMu.Lock()
+		s := cachedPayload
+		cacheMu.Unlock()
+		if s == "" {
+			return redis.NewStringResult("", redis.Nil)
+		}
+		return redis.NewStringResult(s, nil)
+	}).MinTimes(n)
+	mockCache.EXPECT().Set(ctx, cacheKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
+		var b []byte
+		switch x := v.(type) {
+		case []byte:
+			b = x
+		case string:
+			b = []byte(x)
+		default:
+			var err error
+			b, err = json.Marshal(x)
+			if err != nil {
+				return redis.NewStatusResult("", err)
+			}
+		}
+		cacheMu.Lock()
+		cachedPayload = string(b)
+		cacheMu.Unlock()
+		return redis.NewStatusResult("OK", nil)
+	}).Times(1)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/books", repo.FindBooks)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	statusCh := make(chan int, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/books?offset=0&limit=10", nil)
+			r.ServeHTTP(w, req)
+			statusCh <- w.Code
+		}()
+	}
+	wg.Wait()
+	close(statusCh)
+	for code := range statusCh {
+		assert.Equal(t, http.StatusOK, code)
+	}
+
+	if got := selectN.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 coalesced DB query, got %d", got)
+	}
 }


### PR DESCRIPTION
## Summary

Concurrent `GET /books` cache misses for the same offset/limit used to each run Postgres `Find` and Redis `SET`. The handler now uses `singleflight.Group` keyed by a **normalized** cache key (`books_offset_%d_limit_%d` from parsed integers) so one coalesced load populates Redis for all waiters.

## Type of change

- [ ] Bug fix
- [x] New feature (performance / reliability)
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change (minor):** Redis keys for list pagination are now normalized (e.g. `offset=00` and `offset=0` share `books_offset_0_limit_10`). Existing keys using leading-zero query strings become unused until TTL.

## How to test

```bash
go test ./... -race
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] Swagger regenerated; `docs/` updated
- [ ] Environment variables / README (N/A)
- [ ] Docker (N/A)
- [x] No secrets committed

## Related issues

Closes #101

Made with [Cursor](https://cursor.com)