### PR TITLE
perf(api): book list cache invalidation without Redis KEYS (#102)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -54,7 +54,7 @@ const docTemplate = `{
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get a list of all books with optional pagination. Concurrent cache misses for the same offset/limit are coalesced (singleflight) so only one database read and Redis write runs per cache key.",
+                "description": "Get a list of all books with optional pagination. List entries are keyed by a monotonic cache generation (no Redis KEYS). Concurrent cache misses for the same offset/limit and generation are coalesced (singleflight) so only one database read and Redis write runs per cache key.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -48,7 +48,7 @@
                         "ApiKeyAuth": []
                     }
                 ],
-                "description": "Get a list of all books with optional pagination. Concurrent cache misses for the same offset/limit are coalesced (singleflight) so only one database read and Redis write runs per cache key.",
+                "description": "Get a list of all books with optional pagination. List entries are keyed by a monotonic cache generation (no Redis KEYS). Concurrent cache misses for the same offset/limit and generation are coalesced (singleflight) so only one database read and Redis write runs per cache key.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -74,9 +74,10 @@ paths:
       - example
   /books:
     get:
-      description: Get a list of all books with optional pagination. Concurrent cache
-        misses for the same offset/limit are coalesced (singleflight) so only one
-        database read and Redis write runs per cache key.
+      description: Get a list of all books with optional pagination. List entries
+        are keyed by a monotonic cache generation (no Redis KEYS). Concurrent cache
+        misses for the same offset/limit and generation are coalesced (singleflight)
+        so only one database read and Redis write runs per cache key.
       parameters:
       - default: 0
         description: Offset for pagination

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -16,6 +16,35 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+// booksListCacheGenKey is incremented on book writes so list pagination entries
+// (scoped by generation) go stale without Redis KEYS.
+const booksListCacheGenKey = "v1:books:list_cache_gen"
+
+func booksListDataCacheKey(gen int64, offset, limit int) string {
+	return fmt.Sprintf("books_g%d_offset_%d_limit_%d", gen, offset, limit)
+}
+
+func (r *bookRepository) booksListCacheGeneration() int64 {
+	if r == nil || r.RedisClient == nil || r.Ctx == nil {
+		return 0
+	}
+	n, err := r.RedisClient.Get(*r.Ctx, booksListCacheGenKey).Int64()
+	if err != nil {
+		return 0
+	}
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func (r *bookRepository) bumpBooksListCacheGeneration() {
+	if r == nil || r.RedisClient == nil || r.Ctx == nil {
+		return
+	}
+	_, _ = r.RedisClient.Incr(*r.Ctx, booksListCacheGenKey).Result()
+}
+
 type BookRepository interface {
 	Healthcheck(c *gin.Context)
 	FindBooks(c *gin.Context)
@@ -79,7 +108,7 @@ func (r *bookRepository) Healthcheck(c *gin.Context) {
 
 // FindBooks godoc
 // @Summary Get all books with pagination
-// @Description Get a list of all books with optional pagination. Concurrent cache misses for the same offset/limit are coalesced (singleflight) so only one database read and Redis write runs per cache key.
+// @Description Get a list of all books with optional pagination. List entries are keyed by a monotonic cache generation (no Redis KEYS). Concurrent cache misses for the same offset/limit and generation are coalesced (singleflight) so only one database read and Redis write runs per cache key.
 // @Tags books
 // @Security ApiKeyAuth
 // @Produce json
@@ -108,8 +137,8 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 		return
 	}
 
-	// Normalized cache key so equivalent pagination (e.g. "0" vs "00") shares one entry and singleflight.
-	cacheKey := fmt.Sprintf("books_offset_%d_limit_%d", offset, limit)
+	gen := r.booksListCacheGeneration()
+	cacheKey := booksListDataCacheKey(gen, offset, limit)
 
 	// Try fetching the data from Redis first
 	cachedBooks, err := r.RedisClient.Get(*r.Ctx, cacheKey).Result()
@@ -195,14 +224,7 @@ func (r *bookRepository) CreateBook(c *gin.Context) {
 		return
 	}
 
-	// Invalidate cache
-	keysPattern := "books_offset_*"
-	keys, err := appCtx.RedisClient.Keys(*appCtx.Ctx, keysPattern).Result()
-	if err == nil {
-		for _, key := range keys {
-			appCtx.RedisClient.Del(*appCtx.Ctx, key)
-		}
-	}
+	appCtx.bumpBooksListCacheGeneration()
 
 	c.JSON(http.StatusCreated, gin.H{"data": book})
 }
@@ -273,6 +295,8 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 		return
 	}
 
+	r.bumpBooksListCacheGeneration()
+
 	c.JSON(http.StatusOK, gin.H{"data": book})
 }
 
@@ -306,6 +330,8 @@ func (r *bookRepository) DeleteBook(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete book"})
 		return
 	}
+
+	r.bumpBooksListCacheGeneration()
 
 	c.Status(http.StatusNoContent)
 }

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -202,7 +202,7 @@ func TestCreateBookMissingAppCtx(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestCreateBookCacheKeysError(t *testing.T) {
+func TestCreateBookCacheIncrError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -223,52 +223,14 @@ func TestCreateBookCacheKeysError(t *testing.T) {
 	requestBody, _ := json.Marshal(inputBook)
 
 	mockDB.EXPECT().Create(gomock.Any()).Return(&gorm.DB{Error: nil})
-
-	// Mock cache keys error
-	mockCache.EXPECT().Keys(ctx, "books_offset_*").Return(redis.NewStringSliceResult(nil, errors.New("keys error")))
+	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(0, errors.New("incr error")))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
 	req.Header.Set("Content-Type", "application/json")
 	r.ServeHTTP(w, req)
 
-	// Should still succeed even if cache invalidation fails
-	assert.Equal(t, http.StatusCreated, w.Code)
-	assert.Contains(t, w.Body.String(), "New Book")
-}
-
-func TestCreateBookCacheDelError(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockDB := database.NewMockDatabase(ctrl)
-	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
-
-	gin.SetMode(gin.TestMode)
-	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
-
-	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
-	requestBody, _ := json.Marshal(inputBook)
-
-	mockDB.EXPECT().Create(gomock.Any()).Return(&gorm.DB{Error: nil})
-
-	// Mock cache keys success but del error
-	mockCache.EXPECT().Keys(ctx, "books_offset_*").Return(redis.NewStringSliceResult([]string{"key1"}, nil))
-	mockCache.EXPECT().Del(ctx, "key1").Return(redis.NewIntResult(0, errors.New("del error")))
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(w, req)
-
-	// Should still succeed
+	// Should still succeed even if cache generation bump fails
 	assert.Equal(t, http.StatusCreated, w.Code)
 	assert.Contains(t, w.Body.String(), "New Book")
 }
@@ -384,7 +346,10 @@ func TestFindBooksDatabaseError(t *testing.T) {
 	r := gin.Default()
 	r.GET("/books", repo.FindBooks)
 
-	mockCache.EXPECT().Get(ctx, "books_offset_0_limit_10").Return(redis.NewStringResult("", redis.Nil))
+	gomock.InOrder(
+		mockCache.EXPECT().Get(ctx, booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(ctx, booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
+	)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/books?offset=0&limit=10", nil)
@@ -438,6 +403,73 @@ func TestUpdateBookDatabaseErrorOnUpdates(t *testing.T) {
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, w.Body.String(), "Failed to update book")
+}
+
+func TestUpdateBookBumpsListCacheGen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "update_bump.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+	b := models.Book{Title: "t", Author: "a"}
+	if err := db.Create(&b).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.PUT("/book/:id", repo.UpdateBook)
+
+	body, err := json.Marshal(models.UpdateBook{Title: "n", Author: "n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/book/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestDeleteBookBumpsListCacheGen(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "delete_bump.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+	b := models.Book{Title: "del", Author: "me"}
+	if err := db.Create(&b).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.DELETE("/book/:id", repo.DeleteBook)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/book/1", nil)
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
 }
 
 func TestDeleteBookInvalidID(t *testing.T) {
@@ -509,7 +541,10 @@ func TestFindBooks(t *testing.T) {
 
 	books := []models.Book{{Title: "Book One", Author: "Author One"}}
 	cachedData, _ := json.Marshal(books)
-	mockCache.EXPECT().Get(ctx, "books_offset_0_limit_10").Return(redis.NewStringResult(string(cachedData), nil))
+	gomock.InOrder(
+		mockCache.EXPECT().Get(ctx, booksListCacheGenKey).Return(redis.NewStringResult("0", nil)),
+		mockCache.EXPECT().Get(ctx, booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult(string(cachedData), nil)),
+	)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/books?offset=0&limit=10", nil)
@@ -551,10 +586,7 @@ func TestCreateBook(t *testing.T) {
 		return &gorm.DB{Error: nil}
 	})
 
-	// Set up cache mock to simulate key retrieval and deletion
-	keyPattern := "books_offset_*"
-	mockCache.EXPECT().Keys(ctx, keyPattern).Return(redis.NewStringSliceResult([]string{"books_offset_0_limit_10"}, nil))
-	mockCache.EXPECT().Del(ctx, "books_offset_0_limit_10").Return(redis.NewIntResult(1, nil))
+	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(1, nil))
 
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
@@ -789,19 +821,26 @@ func TestFindBooksSingleflightCoalescesDB(t *testing.T) {
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
 
 	const n = 50
-	cacheKey := "books_offset_0_limit_10"
+	dataKey := booksListDataCacheKey(0, 0, 10)
 	var cacheMu sync.Mutex
 	var cachedPayload string
-	mockCache.EXPECT().Get(ctx, cacheKey).DoAndReturn(func(context.Context, string) *redis.StringCmd {
-		cacheMu.Lock()
-		s := cachedPayload
-		cacheMu.Unlock()
-		if s == "" {
+	mockCache.EXPECT().Get(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
+		switch key {
+		case booksListCacheGenKey:
 			return redis.NewStringResult("", redis.Nil)
+		case dataKey:
+			cacheMu.Lock()
+			s := cachedPayload
+			cacheMu.Unlock()
+			if s == "" {
+				return redis.NewStringResult("", redis.Nil)
+			}
+			return redis.NewStringResult(s, nil)
+		default:
+			return redis.NewStringResult("", errors.New("unexpected cache Get key"))
 		}
-		return redis.NewStringResult(s, nil)
-	}).MinTimes(n)
-	mockCache.EXPECT().Set(ctx, cacheKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
+	}).MinTimes(2 * n)
+	mockCache.EXPECT().Set(ctx, dataKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
 		var b []byte
 		switch x := v.(type) {
 		case []byte:

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -15,6 +15,7 @@ import (
 type Cache interface {
 	Get(ctx context.Context, key string) *redis.StringCmd
 	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.StatusCmd
+	Incr(ctx context.Context, key string) *redis.IntCmd
 	Keys(context.Context, string) *redis.StringSliceCmd
 	Del(context.Context, ...string) *redis.IntCmd
 }

--- a/pkg/cache/cache_mock.go
+++ b/pkg/cache/cache_mock.go
@@ -69,6 +69,20 @@ func (mr *MockCacheMockRecorder) Get(ctx, key interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCache)(nil).Get), ctx, key)
 }
 
+// Incr mocks base method.
+func (m *MockCache) Incr(ctx context.Context, key string) *redis.IntCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Incr", ctx, key)
+	ret0, _ := ret[0].(*redis.IntCmd)
+	return ret0
+}
+
+// Incr indicates an expected call of Incr.
+func (mr *MockCacheMockRecorder) Incr(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Incr", reflect.TypeOf((*MockCache)(nil).Incr), ctx, key)
+}
+
 // Keys mocks base method.
 func (m *MockCache) Keys(arg0 context.Context, arg1 string) *redis.StringSliceCmd {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

`CreateBook` no longer runs `KEYS books_offset_*`, which blocks Redis on large keyspaces. Invalidation is a single `INCR v1:books:list_cache_gen`. `GET /books` builds keys as `books_g{gen}_offset_{offset}_limit_{limit}` after reading the current generation (missing key → generation 0). Old list keys are left to TTL.

`UpdateBook` and `DeleteBook` now bump the same generation so list responses stay consistent after mutations.

## Type of change

- [x] Bug fix (operational / Redis safety)
- [ ] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change (cache):** List cache Redis keys changed from `books_offset_*` to `books_g*_offset_*_limit_*`. Existing list keys under the old pattern are no longer read; they expire by TTL.

## How to test

```bash
go test ./... -race
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] Swagger regenerated
- [ ] Env / README (N/A)
- [ ] Docker (N/A)
- [x] No secrets committed

## Related issues

Closes #102

Made with [Cursor](https://cursor.com)