### PR TITLE
fix(api): cap FindBooks limit and validate offset/limit (#104)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -66,14 +66,14 @@ const docTemplate = `{
                     {
                         "type": "integer",
                         "default": 0,
-                        "description": "Offset for pagination",
+                        "description": "Offset for pagination (must be \u003e= 0)",
                         "name": "offset",
                         "in": "query"
                     },
                     {
                         "type": "integer",
                         "default": 10,
-                        "description": "Limit for pagination",
+                        "description": "Limit for pagination (minimum 1, capped at 100)",
                         "name": "limit",
                         "in": "query"
                     }
@@ -86,6 +86,12 @@ const docTemplate = `{
                             "items": {
                                 "$ref": "#/definitions/models.Book"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "500": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -60,14 +60,14 @@
                     {
                         "type": "integer",
                         "default": 0,
-                        "description": "Offset for pagination",
+                        "description": "Offset for pagination (must be \u003e= 0)",
                         "name": "offset",
                         "in": "query"
                     },
                     {
                         "type": "integer",
                         "default": 10,
-                        "description": "Limit for pagination",
+                        "description": "Limit for pagination (minimum 1, capped at 100)",
                         "name": "limit",
                         "in": "query"
                     }
@@ -80,6 +80,12 @@
                             "items": {
                                 "$ref": "#/definitions/models.Book"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "500": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -82,12 +82,12 @@ paths:
         Redis write runs per cache key.
       parameters:
       - default: 0
-        description: Offset for pagination
+        description: Offset for pagination (must be >= 0)
         in: query
         name: offset
         type: integer
       - default: 10
-        description: Limit for pagination
+        description: Limit for pagination (minimum 1, capped at 100)
         in: query
         name: limit
         type: integer
@@ -100,6 +100,10 @@ paths:
             items:
               $ref: '#/definitions/models.Book'
             type: array
+        "400":
+          description: Bad Request
+          schema:
+            type: string
         "500":
           description: Internal Server Error
           schema:

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -21,6 +21,11 @@ import (
 // (scoped by generation) go stale without Redis KEYS.
 const booksListCacheGenKey = "v1:books:list_cache_gen"
 
+const (
+	findBooksMinLimit = 1
+	findBooksMaxLimit = 100
+)
+
 func booksListDataCacheKey(gen int64, offset, limit int) string {
 	return fmt.Sprintf("books_g%d_offset_%d_limit_%d", gen, offset, limit)
 }
@@ -113,9 +118,10 @@ func (r *bookRepository) Healthcheck(c *gin.Context) {
 // @Tags books
 // @Security ApiKeyAuth
 // @Produce json
-// @Param offset query int false "Offset for pagination" default(0)
-// @Param limit query int false "Limit for pagination" default(10)
+// @Param offset query int false "Offset for pagination (must be >= 0)" default(0)
+// @Param limit query int false "Limit for pagination (minimum 1, capped at 100)" default(10)
 // @Success 200 {array} models.Book "Successfully retrieved list of books"
+// @Failure 400 {string} string "Bad Request"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books [get]
 func (r *bookRepository) FindBooks(c *gin.Context) {
@@ -135,6 +141,18 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid limit format"})
 		return
+	}
+
+	if offset < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be >= 0"})
+		return
+	}
+	if limit < findBooksMinLimit {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be at least 1"})
+		return
+	}
+	if limit > findBooksMaxLimit {
+		limit = findBooksMaxLimit
 	}
 
 	gen := r.booksListCacheGeneration()

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -112,6 +113,91 @@ func TestFindBooksInvalidLimit(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "Invalid limit format")
+}
+
+func TestFindBooksNegativeOffset(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database.NewMockDatabase(ctrl)
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(mockDB, mockCache, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/books", repo.FindBooks)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/books?offset=-1&limit=10", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "offset must be")
+}
+
+func TestFindBooksLimitBelowOne(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database.NewMockDatabase(ctrl)
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(mockDB, mockCache, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/books", repo.FindBooks)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/books?offset=0&limit=0", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "limit must be at least 1")
+}
+
+func TestFindBooksLimitCappedAtMax(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "cap_limit.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 120; i++ {
+		if err := db.Create(&models.Book{Title: "b" + strconv.Itoa(i), Author: "a"}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockCache := cache.NewMockCache(ctrl)
+	ctx := context.Background()
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+
+	gomock.InOrder(
+		mockCache.EXPECT().Get(ctx, booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(ctx, booksListDataCacheKey(0, 0, findBooksMaxLimit)).Return(redis.NewStringResult("", redis.Nil)),
+	)
+	mockCache.EXPECT().Set(ctx, booksListDataCacheKey(0, 0, findBooksMaxLimit), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.GET("/books", repo.FindBooks)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/books?offset=0&limit=500", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data []models.Book `json:"data"`
+	}
+	assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Len(t, resp.Data, findBooksMaxLimit)
 }
 
 func TestCreateBookDatabaseError(t *testing.T) {
@@ -321,7 +407,8 @@ func TestFindBooksDatabaseError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	sqlDB, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	dbPath := filepath.Join(t.TempDir(), "findbooks_db_err.sqlite")
+	sqlDB, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

`GET /books` now rejects **negative `offset`** and **`limit` below 1** with HTTP 400. Requested `limit` above **100** is **capped at 100** before cache lookup, singleflight, and the GORM query so clients cannot force unbounded reads.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change:** Requests with `limit > 100` now receive at most 100 rows (previously honored). Requests with `offset < 0` or `limit < 1` now return **400** instead of delegating odd behavior to the database.

## How to test

```bash
go test ./... -race
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] Swagger regenerated
- [x] No secrets committed

## Related issues

Closes #104

Made with [Cursor](https://cursor.com)