### PR TITLE
fix(api): LoginHandler LoginUser validation consistency (#105)

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -20,7 +20,6 @@ type UserRepository interface {
 	RegisterHandler(c *gin.Context)
 }
 
-// bookRepository holds shared resources like database and Redis client
 type userRepository struct {
 	DB  database.Database
 	Ctx *context.Context
@@ -54,7 +53,7 @@ func (r *userRepository) LoginHandler(c *gin.Context) {
 	var dbUser models.User
 
 	if err := c.ShouldBindJSON(&incoming); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Bad Request"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -80,7 +80,30 @@ func TestLoginHandlerInvalidJSON(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Bad Request")
+	assert.Contains(t, w.Body.String(), "error")
+}
+
+func TestLoginHandlerBindValidationLoginUser(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := database.NewMockDatabase(ctrl)
+	ctx := context.Background()
+	repo := NewUserRepository(mockDB, &ctx)
+
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.POST("/login", repo.LoginHandler)
+
+	// Missing password — binding is on models.LoginUser, not models.User
+	body, _ := json.Marshal(map[string]string{"username": "onlyuser"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/login", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Password")
 }
 
 func TestLoginHandlerUserNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

`LoginHandler` already binds `models.LoginUser` (not `models.User`) for JSON input; `models.User` is only used to load the stored row after lookup.

This PR aligns **bind error responses** with `RegisterHandler` by returning `err.Error()` instead of a generic `"Bad Request"` string, removes a mistaken `bookRepository` comment on `userRepository`, and adds `TestLoginHandlerBindValidationLoginUser` to assert `binding:"required"` on `LoginUser` (missing password → 400, body mentions `Password`).

## Type of change

- [x] Bug fix (API consistency / validation feedback)
- [ ] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change (minor):** HTTP 400 responses for malformed login JSON now use `{"error": "<validator/parser message>"}` instead of `{"error": "Bad Request"}`.

## How to test

```bash
go test ./pkg/api/... -race -run 'Login|Register'
```

## Related issues

Closes #105

Made with [Cursor](https://cursor.com)