### PR TITLE
fix(api): duplicate username returns 409; generic 500 on register (#106)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -421,6 +421,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -415,6 +415,12 @@
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -310,6 +310,10 @@ paths:
           description: Bad Request
           schema:
             type: string
+        "409":
+          description: Conflict
+          schema:
+            type: string
         "500":
           description: Internal Server Error
           schema:

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -3,11 +3,11 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/database"
 	"golang-rest-api-template/pkg/models"
 	"net/http"
+	"strings"
 
 	"gorm.io/gorm"
 
@@ -23,6 +23,25 @@ type UserRepository interface {
 type userRepository struct {
 	DB  database.Database
 	Ctx *context.Context
+}
+
+// registerUsernameConflict detects unique violations on user registration.
+// Prefer gorm.ErrDuplicatedKey; fall back to driver strings when translation is missing.
+func registerUsernameConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	if strings.Contains(s, "unique constraint failed") {
+		return true
+	}
+	if strings.Contains(s, "duplicate key") && strings.Contains(s, "unique") {
+		return true
+	}
+	return false
 }
 
 func NewUserRepository(db database.Database, ctx *context.Context) *userRepository {
@@ -92,6 +111,7 @@ func (r *userRepository) LoginHandler(c *gin.Context) {
 // @Param   user     body    models.LoginUser     true        "User registration object"
 // @Success 201 {string} string	"Successfully registered"
 // @Failure 400 {string} string "Bad Request"
+// @Failure 409 {string} string "Conflict"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /register [post]
 func (r *userRepository) RegisterHandler(c *gin.Context) {
@@ -114,7 +134,11 @@ func (r *userRepository) RegisterHandler(c *gin.Context) {
 
 	// Save the user to the database
 	if err := r.DB.Create(&newUser).Error; err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Could not save user: %v", err)})
+		if registerUsernameConflict(err) {
+			c.JSON(http.StatusConflict, gin.H{"error": "username already taken"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not save user"})
 		return
 	}
 

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -9,6 +9,7 @@ import (
 	"golang-rest-api-template/pkg/models"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"gorm.io/gorm"
@@ -206,5 +207,47 @@ func TestRegisterHandlerDBError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
-	assert.Contains(t, w.Body.String(), "Could not save user")
+	body := w.Body.String()
+	assert.Contains(t, body, "Could not save user")
+	assert.NotContains(t, body, "ErrInvalidDB")
+}
+
+func TestRegisterHandlerDuplicateUsername(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "register_dup.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := NewUserRepository(&database.GormDatabase{DB: db}, nil)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.POST("/register", repo.RegisterHandler)
+
+	login := models.LoginUser{Username: "alice", Password: "hunter2!aa"}
+	payload, err := json.Marshal(login)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := func() *http.Request {
+		req, err := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(payload))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req
+	}
+
+	w1 := httptest.NewRecorder()
+	r.ServeHTTP(w1, req())
+	assert.Equal(t, http.StatusCreated, w1.Code)
+
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req())
+	assert.Equal(t, http.StatusConflict, w2.Code)
+	assert.Contains(t, w2.Body.String(), "username already taken")
 }


### PR DESCRIPTION
## Summary

`RegisterHandler` no longer returns **500** with raw `fmt` DB text on unique username violations. Those map to **409 Conflict** with `{"error":"username already taken"}`. Other persistence failures return **500** with a generic `Could not save user` message (no driver details).

Detection uses `errors.Is(err, gorm.ErrDuplicatedKey)` when the driver error is translated, plus conservative **string fallbacks** for common SQLite / Postgres unique messages when translation is missing through the `database.Database` wrapper.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change:** Duplicate registration now returns **409** instead of **500**, with a different JSON `error` string.

## How to test

```bash
go test ./... -race
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] Swagger regenerated
- [x] No secrets committed

## Related issues

Closes #106

Made with [Cursor](https://cursor.com)