### PR TITLE
refactor(api): remove appCtx middleware; CreateBook uses receiver (#107)

### DIFF
--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -218,16 +218,6 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books [post]
 func (r *bookRepository) CreateBook(c *gin.Context) {
-	appCtxInterface, exists := c.Get("appCtx")
-	if !exists {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
-		return
-	}
-	appCtx, ok := appCtxInterface.(*bookRepository)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
-		return
-	}
 	var input models.CreateBook
 
 	if err := c.ShouldBindJSON(&input); err != nil {
@@ -237,12 +227,12 @@ func (r *bookRepository) CreateBook(c *gin.Context) {
 
 	book := models.Book{Title: input.Title, Author: input.Author}
 
-	if err := appCtx.DB.Create(&book).Error; err != nil {
+	if err := r.DB.Create(&book).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book"})
 		return
 	}
 
-	appCtx.bumpBooksListCacheGeneration()
+	r.bumpBooksListCacheGeneration()
 
 	c.JSON(http.StatusCreated, gin.H{"data": book})
 }

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -211,10 +211,7 @@ func TestCreateBookDatabaseError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
 	requestBody, err := json.Marshal(inputBook)
@@ -249,10 +246,7 @@ func TestCreateBookBindError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/books", bytes.NewBufferString("invalid json"))
@@ -261,31 +255,6 @@ func TestCreateBookBindError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "error")
-}
-
-func TestCreateBookMissingAppCtx(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockDB := database.NewMockDatabase(ctrl)
-	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
-
-	gin.SetMode(gin.TestMode)
-	r := gin.Default()
-	r.POST("/books", repo.CreateBook) // Not setting appCtx
-
-	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
-	requestBody, _ := json.Marshal(inputBook)
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestCreateBookCacheIncrError(t *testing.T) {
@@ -300,10 +269,7 @@ func TestCreateBookCacheIncrError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
 	requestBody, _ := json.Marshal(inputBook)
@@ -654,11 +620,7 @@ func TestCreateBook(t *testing.T) {
 	// Set up Gin
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		// Set the appCtx in the Gin context
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	// Example data for the test
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -22,13 +22,6 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func ContextMiddleware(bookRepository BookRepository) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		c.Set("appCtx", bookRepository)
-		c.Next()
-	}
-}
-
 func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db database.Database, redisClient cache.Cache, ctx *context.Context) *gin.Engine {
 	bookRepository := NewBookRepository(db, redisClient, ctx)
 	userRepository := NewUserRepository(db, ctx)
@@ -39,7 +32,6 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 	}
 	r.Use(middleware.MaxRequestBody(maxRequestBodyBytesFromEnv()))
 	r.Use(middleware.RequestID())
-	r.Use(ContextMiddleware(bookRepository))
 
 	//r.Use(gin.Logger())
 	r.Use(middleware.Logger(logger, mongoCollection))


### PR DESCRIPTION
## Summary

Removes `ContextMiddleware` and the `c.Get("appCtx")` / type-assert path from `CreateBook`. The handler uses the existing `*bookRepository` receiver (`r.DB`, `r.bumpBooksListCacheGeneration`) like `FindBooks` / `UpdateBook`.

Tests register `POST /books` with `repo.CreateBook` directly; `TestCreateBookMissingAppCtx` removed as obsolete.

## Type of change

- [ ] Bug fix
- [x] Refactor / cleanup
- [ ] Breaking change (API contract unchanged)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

## Related issues

Closes #107

Made with [Cursor](https://cursor.com)