### PR TITLE
refactor(api): request-scoped context for Redis; remove repo *Context (#108)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"golang-rest-api-template/pkg/api"
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/cache"
@@ -53,7 +52,6 @@ func main() {
 	db := database.NewDatabase()
 	dbWrapper := &database.GormDatabase{DB: db}
 	mongo := database.SetupMongoDB()
-	ctx := context.Background()
 	logger, _ := zap.NewProduction()
 	defer logger.Sync()
 
@@ -61,7 +59,7 @@ func main() {
 	// Gin's init already applied os.Getenv("GIN_MODE"); do not override here.
 	// Use GIN_MODE=release in production so Security/XSS middleware run (pkg/api/router.go).
 
-	r := api.NewRouter(logger, mongo, dbWrapper, redisClient, &ctx)
+	r := api.NewRouter(logger, mongo, dbWrapper, redisClient)
 
 	if err := r.Run(":8001"); err != nil {
 		log.Fatal(err)

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -30,11 +30,11 @@ func booksListDataCacheKey(gen int64, offset, limit int) string {
 	return fmt.Sprintf("books_g%d_offset_%d_limit_%d", gen, offset, limit)
 }
 
-func (r *bookRepository) booksListCacheGeneration() int64 {
-	if r == nil || r.RedisClient == nil || r.Ctx == nil {
+func (r *bookRepository) booksListCacheGeneration(ctx context.Context) int64 {
+	if r == nil || r.RedisClient == nil {
 		return 0
 	}
-	n, err := r.RedisClient.Get(*r.Ctx, booksListCacheGenKey).Int64()
+	n, err := r.RedisClient.Get(ctx, booksListCacheGenKey).Int64()
 	if err != nil {
 		return 0
 	}
@@ -44,11 +44,11 @@ func (r *bookRepository) booksListCacheGeneration() int64 {
 	return n
 }
 
-func (r *bookRepository) bumpBooksListCacheGeneration() {
-	if r == nil || r.RedisClient == nil || r.Ctx == nil {
+func (r *bookRepository) bumpBooksListCacheGeneration(ctx context.Context) {
+	if r == nil || r.RedisClient == nil {
 		return
 	}
-	_, _ = r.RedisClient.Incr(*r.Ctx, booksListCacheGenKey).Result()
+	_, _ = r.RedisClient.Incr(ctx, booksListCacheGenKey).Result()
 }
 
 type BookRepository interface {
@@ -84,16 +84,14 @@ var (
 type bookRepository struct {
 	DB          database.Database
 	RedisClient cache.Cache
-	Ctx         *context.Context
 	listBooksSF singleflight.Group
 }
 
-// NewAppContext creates a new AppContext
-func NewBookRepository(db database.Database, redisClient cache.Cache, ctx *context.Context) *bookRepository {
+// NewBookRepository returns a bookRepository backed by db and optional redisClient.
+func NewBookRepository(db database.Database, redisClient cache.Cache) *bookRepository {
 	return &bookRepository{
 		DB:          db,
 		RedisClient: redisClient,
-		Ctx:         ctx,
 	}
 }
 
@@ -155,11 +153,12 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 		limit = findBooksMaxLimit
 	}
 
-	gen := r.booksListCacheGeneration()
+	reqCtx := c.Request.Context()
+	gen := r.booksListCacheGeneration(reqCtx)
 	cacheKey := booksListDataCacheKey(gen, offset, limit)
 
 	// Try fetching the data from Redis first
-	cachedBooks, err := r.RedisClient.Get(*r.Ctx, cacheKey).Result()
+	cachedBooks, err := r.RedisClient.Get(reqCtx, cacheKey).Result()
 	if err == nil {
 		err := json.Unmarshal([]byte(cachedBooks), &books)
 		if err != nil {
@@ -180,7 +179,7 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 		if err != nil {
 			return nil, fmt.Errorf("%w: %v", errListBooksSFMarshal, err)
 		}
-		if err := r.RedisClient.Set(*r.Ctx, cacheKey, serializedBooks, time.Minute).Err(); err != nil {
+		if err := r.RedisClient.Set(reqCtx, cacheKey, serializedBooks, time.Minute).Err(); err != nil {
 			return nil, fmt.Errorf("%w: %v", errListBooksSFRedis, err)
 		}
 		return loaded, nil
@@ -218,16 +217,6 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books [post]
 func (r *bookRepository) CreateBook(c *gin.Context) {
-	appCtxInterface, exists := c.Get("appCtx")
-	if !exists {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
-		return
-	}
-	appCtx, ok := appCtxInterface.(*bookRepository)
-	if !ok {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
-		return
-	}
 	var input models.CreateBook
 
 	if err := c.ShouldBindJSON(&input); err != nil {
@@ -237,12 +226,12 @@ func (r *bookRepository) CreateBook(c *gin.Context) {
 
 	book := models.Book{Title: input.Title, Author: input.Author}
 
-	if err := appCtx.DB.Create(&book).Error; err != nil {
+	if err := r.DB.Create(&book).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book"})
 		return
 	}
 
-	appCtx.bumpBooksListCacheGeneration()
+	r.bumpBooksListCacheGeneration(c.Request.Context())
 
 	c.JSON(http.StatusCreated, gin.H{"data": book})
 }
@@ -313,7 +302,7 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 		return
 	}
 
-	r.bumpBooksListCacheGeneration()
+	r.bumpBooksListCacheGeneration(c.Request.Context())
 
 	c.JSON(http.StatusOK, gin.H{"data": book})
 }
@@ -349,7 +338,7 @@ func (r *bookRepository) DeleteBook(c *gin.Context) {
 		return
 	}
 
-	r.bumpBooksListCacheGeneration()
+	r.bumpBooksListCacheGeneration(c.Request.Context())
 
 	c.Status(http.StatusNoContent)
 }

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -33,9 +33,8 @@ func TestNewBookRepository(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	mockCtx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &mockCtx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	assert.NotNil(t, repo, "NewBookRepository should return a non-nil instance of bookRepository")
 	assert.Equal(t, mockDB, repo.DB, "DB should be set to the mock database instance")
@@ -48,9 +47,8 @@ func TestHealthcheck(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	// Set up Gin
 	gin.SetMode(gin.TestMode)
@@ -77,9 +75,8 @@ func TestFindBooksInvalidOffset(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -99,9 +96,8 @@ func TestFindBooksInvalidLimit(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -121,8 +117,7 @@ func TestFindBooksNegativeOffset(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -142,8 +137,7 @@ func TestFindBooksLimitBelowOne(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -175,14 +169,13 @@ func TestFindBooksLimitCappedAtMax(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
 	gomock.InOrder(
-		mockCache.EXPECT().Get(ctx, booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
-		mockCache.EXPECT().Get(ctx, booksListDataCacheKey(0, 0, findBooksMaxLimit)).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), booksListDataCacheKey(0, 0, findBooksMaxLimit)).Return(redis.NewStringResult("", redis.Nil)),
 	)
-	mockCache.EXPECT().Set(ctx, booksListDataCacheKey(0, 0, findBooksMaxLimit), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
+	mockCache.EXPECT().Set(gomock.Any(), booksListDataCacheKey(0, 0, findBooksMaxLimit), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -206,15 +199,11 @@ func TestCreateBookDatabaseError(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
 	requestBody, err := json.Marshal(inputBook)
@@ -243,16 +232,12 @@ func TestCreateBookBindError(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/books", bytes.NewBufferString("invalid json"))
@@ -263,53 +248,24 @@ func TestCreateBookBindError(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "error")
 }
 
-func TestCreateBookMissingAppCtx(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockDB := database.NewMockDatabase(ctrl)
-	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
-
-	gin.SetMode(gin.TestMode)
-	r := gin.Default()
-	r.POST("/books", repo.CreateBook) // Not setting appCtx
-
-	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
-	requestBody, _ := json.Marshal(inputBook)
-
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
-	req.Header.Set("Content-Type", "application/json")
-	r.ServeHTTP(w, req)
-
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
-}
-
 func TestCreateBookCacheIncrError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
 	requestBody, _ := json.Marshal(inputBook)
 
 	mockDB.EXPECT().Create(gomock.Any()).Return(&gorm.DB{Error: nil})
-	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(0, errors.New("incr error")))
+	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(0, errors.New("incr error")))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
@@ -326,8 +282,7 @@ func TestUpdateBookInvalidID(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -350,8 +305,7 @@ func TestUpdateBookNotFound(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -379,8 +333,7 @@ func TestUpdateBookBindError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -426,16 +379,15 @@ func TestFindBooksDatabaseError(t *testing.T) {
 
 	gdb := &database.GormDatabase{DB: sqlDB}
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(gdb, mockCache, &ctx)
+	repo := NewBookRepository(gdb, mockCache)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.GET("/books", repo.FindBooks)
 
 	gomock.InOrder(
-		mockCache.EXPECT().Get(ctx, booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
-		mockCache.EXPECT().Get(ctx, booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
 	)
 
 	w := httptest.NewRecorder()
@@ -470,8 +422,7 @@ func TestUpdateBookDatabaseErrorOnUpdates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
-	repo := NewBookRepository(&database.GormDatabase{DB: db}, nil, &ctx)
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -509,10 +460,9 @@ func TestUpdateBookBumpsListCacheGen(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
 
-	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.PUT("/book/:id", repo.UpdateBook)
@@ -545,10 +495,9 @@ func TestDeleteBookBumpsListCacheGen(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
 
-	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.DELETE("/book/:id", repo.DeleteBook)
@@ -564,8 +513,7 @@ func TestDeleteBookInvalidID(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -584,8 +532,7 @@ func TestDeleteBookNotFound(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -611,9 +558,8 @@ func TestFindBooks(t *testing.T) {
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
 	mockGormDB := database.NewMockDatabase(ctrl) // Correct type for GORM DB operations
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	// Set up Gin
 	gin.SetMode(gin.TestMode)
@@ -629,8 +575,8 @@ func TestFindBooks(t *testing.T) {
 	books := []models.Book{{Title: "Book One", Author: "Author One"}}
 	cachedData, _ := json.Marshal(books)
 	gomock.InOrder(
-		mockCache.EXPECT().Get(ctx, booksListCacheGenKey).Return(redis.NewStringResult("0", nil)),
-		mockCache.EXPECT().Get(ctx, booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult(string(cachedData), nil)),
+		mockCache.EXPECT().Get(gomock.Any(), booksListCacheGenKey).Return(redis.NewStringResult("0", nil)),
+		mockCache.EXPECT().Get(gomock.Any(), booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult(string(cachedData), nil)),
 	)
 
 	w := httptest.NewRecorder()
@@ -647,18 +593,13 @@ func TestCreateBook(t *testing.T) {
 
 	mockDB := database.NewMockDatabase(ctrl)
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
 
-	repo := NewBookRepository(mockDB, mockCache, &ctx)
+	repo := NewBookRepository(mockDB, mockCache)
 
 	// Set up Gin
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", func(c *gin.Context) {
-		// Set the appCtx in the Gin context
-		c.Set("appCtx", repo)
-		repo.CreateBook(c)
-	})
+	r.POST("/books", repo.CreateBook)
 
 	// Example data for the test
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
@@ -673,7 +614,7 @@ func TestCreateBook(t *testing.T) {
 		return &gorm.DB{Error: nil}
 	})
 
-	mockCache.EXPECT().Incr(ctx, booksListCacheGenKey).Return(redis.NewIntResult(1, nil))
+	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(1, nil))
 
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
@@ -695,8 +636,7 @@ func TestFindBook(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	// Set up Gin
 	gin.SetMode(gin.TestMode)
@@ -750,8 +690,7 @@ func TestFindBookNotFound(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -775,8 +714,7 @@ func TestFindBookRejectsInvalidID(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -796,8 +734,7 @@ func TestDeleteBook(t *testing.T) {
 
 	// Create mock for the database
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	// Set up Gin for testing
 	gin.SetMode(gin.TestMode)
@@ -842,8 +779,7 @@ func TestDeleteBookDatabaseErrorOnDelete(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(mockDB, nil, &ctx)
+	repo := NewBookRepository(mockDB, nil)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -904,14 +840,13 @@ func TestFindBooksSingleflightCoalescesDB(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
 	const n = 50
 	dataKey := booksListDataCacheKey(0, 0, 10)
 	var cacheMu sync.Mutex
 	var cachedPayload string
-	mockCache.EXPECT().Get(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
+	mockCache.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
 		switch key {
 		case booksListCacheGenKey:
 			return redis.NewStringResult("", redis.Nil)
@@ -927,7 +862,7 @@ func TestFindBooksSingleflightCoalescesDB(t *testing.T) {
 			return redis.NewStringResult("", errors.New("unexpected cache Get key"))
 		}
 	}).MinTimes(2 * n)
-	mockCache.EXPECT().Set(ctx, dataKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
+	mockCache.EXPECT().Set(gomock.Any(), dataKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
 		var b []byte
 		switch x := v.(type) {
 		case []byte:
@@ -999,13 +934,12 @@ func TestFindBooksLeadingZerosShareListCache(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockCache := cache.NewMockCache(ctrl)
-	ctx := context.Background()
-	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache, &ctx)
+	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
 	dataKey := booksListDataCacheKey(0, 0, 10)
 	var cacheMu sync.Mutex
 	var cachedPayload string
-	mockCache.EXPECT().Get(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
+	mockCache.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
 		switch key {
 		case booksListCacheGenKey:
 			return redis.NewStringResult("", redis.Nil)
@@ -1021,7 +955,7 @@ func TestFindBooksLeadingZerosShareListCache(t *testing.T) {
 			return redis.NewStringResult("", errors.New("unexpected cache Get key"))
 		}
 	}).MinTimes(4)
-	mockCache.EXPECT().Set(ctx, dataKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
+	mockCache.EXPECT().Set(gomock.Any(), dataKey, gomock.Any(), time.Minute).DoAndReturn(func(_ context.Context, _ string, v interface{}, _ time.Duration) *redis.StatusCmd {
 		var b []byte
 		switch x := v.(type) {
 		case []byte:

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"os"
 	"strconv"
 	"strings"
@@ -29,9 +28,9 @@ func ContextMiddleware(bookRepository BookRepository) gin.HandlerFunc {
 	}
 }
 
-func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db database.Database, redisClient cache.Cache, ctx *context.Context) *gin.Engine {
-	bookRepository := NewBookRepository(db, redisClient, ctx)
-	userRepository := NewUserRepository(db, ctx)
+func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db database.Database, redisClient cache.Cache) *gin.Engine {
+	bookRepository := NewBookRepository(db, redisClient)
+	userRepository := NewUserRepository(db)
 
 	r := gin.Default()
 	if err := configureTrustedProxies(r); err != nil {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/database"
@@ -21,8 +20,7 @@ type UserRepository interface {
 }
 
 type userRepository struct {
-	DB  database.Database
-	Ctx *context.Context
+	DB database.Database
 }
 
 // registerUsernameConflict detects unique violations on user registration.
@@ -44,11 +42,8 @@ func registerUsernameConflict(err error) bool {
 	return false
 }
 
-func NewUserRepository(db database.Database, ctx *context.Context) *userRepository {
-	return &userRepository{
-		DB:  db,
-		Ctx: ctx,
-	}
+func NewUserRepository(db database.Database) *userRepository {
+	return &userRepository{DB: db}
 }
 
 // @BasePath /api/v1

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/database"
@@ -25,9 +24,8 @@ func TestNewUserRepository(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	mockCtx := context.Background()
 
-	repo := NewUserRepository(mockDB, &mockCtx)
+	repo := NewUserRepository(mockDB)
 
 	assert.NotNil(t, repo, "NewUserRepository should return a non-nil instance of userRepository")
 	assert.Equal(t, mockDB, repo.DB, "DB should be set to the mock database instance")
@@ -41,7 +39,7 @@ func TestLoginHandlerSuccess(t *testing.T) {
 	}
 	db.AutoMigrate(&models.User{})
 
-	repo := NewUserRepository(&database.GormDatabase{DB: db}, nil)
+	repo := NewUserRepository(&database.GormDatabase{DB: db})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -68,8 +66,7 @@ func TestLoginHandlerInvalidJSON(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewUserRepository(mockDB, &ctx)
+	repo := NewUserRepository(mockDB)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -89,8 +86,7 @@ func TestLoginHandlerBindValidationLoginUser(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewUserRepository(mockDB, &ctx)
+	repo := NewUserRepository(mockDB)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -115,7 +111,7 @@ func TestLoginHandlerUserNotFound(t *testing.T) {
 	}
 	db.AutoMigrate(&models.User{})
 
-	repo := NewUserRepository(&database.GormDatabase{DB: db}, nil)
+	repo := NewUserRepository(&database.GormDatabase{DB: db})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -141,7 +137,7 @@ func TestLoginHandlerWrongPassword(t *testing.T) {
 	}
 	db.AutoMigrate(&models.User{})
 
-	repo := NewUserRepository(&database.GormDatabase{DB: db}, nil)
+	repo := NewUserRepository(&database.GormDatabase{DB: db})
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -168,8 +164,7 @@ func TestRegisterHandlerInvalidJSON(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewUserRepository(mockDB, &ctx)
+	repo := NewUserRepository(mockDB)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -189,8 +184,7 @@ func TestRegisterHandlerDBError(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockDB := database.NewMockDatabase(ctrl)
-	ctx := context.Background()
-	repo := NewUserRepository(mockDB, &ctx)
+	repo := NewUserRepository(mockDB)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -222,7 +216,7 @@ func TestRegisterHandlerDuplicateUsername(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repo := NewUserRepository(&database.GormDatabase{DB: db}, nil)
+	repo := NewUserRepository(&database.GormDatabase{DB: db})
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.POST("/register", repo.RegisterHandler)


### PR DESCRIPTION
## Summary
- Removes `*context.Context` fields from `bookRepository` and `userRepository` (user repo never used it).
- Redis list cache reads/writes and generation bumps use `c.Request.Context()` from the Gin handler.
- `CreateBook` uses the handler receiver for DB and cache bump (no `appCtx` lookup).
- `NewRouter` / constructors no longer accept a background context pointer; `main` no longer allocates one for the API layer.

## Issue
Closes #108

Made with [Cursor](https://cursor.com)