### PR TITLE
perf(middleware): bounded async Mongo access logs (#111)

### DIFF
--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -10,7 +11,63 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	mongoAccessLogQueueSize     = 256
+	mongoAccessLogInsertTimeout = 5 * time.Second
+	mongoAccessLogDropLogEvery  = 100
+)
+
+// mongoAccessLogQueue buffers access-log documents and inserts them from a
+// single worker so HTTP handlers do not block on MongoDB. If the buffer fills,
+// new entries are dropped and a throttled warning is emitted.
+type mongoAccessLogQueue struct {
+	collection *mongo.Collection
+	logger     *zap.Logger
+	ch         chan bson.M
+	dropped    atomic.Uint64
+}
+
+func newMongoAccessLogQueue(collection *mongo.Collection, logger *zap.Logger) *mongoAccessLogQueue {
+	if collection == nil {
+		return nil
+	}
+	q := &mongoAccessLogQueue{
+		collection: collection,
+		logger:     logger,
+		ch:         make(chan bson.M, mongoAccessLogQueueSize),
+	}
+	go q.worker()
+	return q
+}
+
+func (q *mongoAccessLogQueue) worker() {
+	for doc := range q.ch {
+		ctx, cancel := context.WithTimeout(context.Background(), mongoAccessLogInsertTimeout)
+		_, err := q.collection.InsertOne(ctx, doc)
+		cancel()
+		if err != nil {
+			q.logger.Error("Failed to log to MongoDB", zap.Error(err))
+		}
+	}
+}
+
+func (q *mongoAccessLogQueue) enqueue(doc bson.M) {
+	if q == nil {
+		return
+	}
+	select {
+	case q.ch <- doc:
+	default:
+		n := q.dropped.Add(1)
+		if n == 1 || n%mongoAccessLogDropLogEvery == 0 {
+			q.logger.Warn("mongodb access log queue full; dropping entries",
+				zap.Uint64("dropped_total", n))
+		}
+	}
+}
+
 func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
+	mongoQ := newMongoAccessLogQueue(collection, logger)
 	return func(c *gin.Context) {
 		// Start timer
 		start := time.Now()
@@ -45,9 +102,6 @@ func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
 			"request_id": requestID,
 		}
 
-		// Log to MongoDB
-		if _, err := collection.InsertOne(context.TODO(), logEntry); err != nil {
-			logger.Error("Failed to log to MongoDB", zap.Error(err))
-		}
+		mongoQ.enqueue(logEntry)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a small bounded queue and background worker so request handlers no longer block on `InsertOne`.
- Each insert uses `context.WithTimeout(context.Background(), 5s)` instead of `context.TODO()`.
- When the queue is full, documents are dropped; a warning is logged on the first drop and every 100 drops thereafter to avoid log storms.

## Issue
Closes #111

Made with [Cursor](https://cursor.com)