### PR TITLE
test: JWT/API test credentials in init (#112)

### DIFF
--- a/pkg/api/main_test.go
+++ b/pkg/api/main_test.go
@@ -2,8 +2,6 @@ package api
 
 import (
 	"bytes"
-	"os"
-	"testing"
 
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/middleware"
@@ -14,7 +12,9 @@ import (
 // testAPISecretKey is the X-API-Key value expected by middleware in tests (32 bytes).
 const testAPISecretKey = "01234567890123456789012345678901"
 
-func TestMain(m *testing.M) {
+func init() {
+	// Runs for the full package test binary and whenever this file is linked (e.g. with
+	// `go test main_test.go other_test.go`); configures JWT + API key before any test.
 	gin.SetMode(gin.TestMode)
 	if err := auth.SetJWTSigningKey(bytes.Repeat([]byte("t"), auth.MinJWTSecretKeyBytes)); err != nil {
 		panic(err)
@@ -22,5 +22,4 @@ func TestMain(m *testing.M) {
 	if err := middleware.SetAPISecretKey([]byte(testAPISecretKey)); err != nil {
 		panic(err)
 	}
-	os.Exit(m.Run())
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"bytes"
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -11,12 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMain(m *testing.M) {
-	// Same-length key as production minimum; tests do not read JWT_SECRET_KEY at init.
+func init() {
+	// Same-length key as production minimum; runs even when TestMain is not linked
+	// (e.g. `go test auth_test.go` alone).
 	if err := SetJWTSigningKey(bytes.Repeat([]byte("k"), MinJWTSecretKeyBytes)); err != nil {
 		panic(err)
 	}
-	os.Exit(m.Run())
 }
 
 func TestHashPassword(t *testing.T) {

--- a/pkg/middleware/authenticateJWT_test.go
+++ b/pkg/middleware/authenticateJWT_test.go
@@ -6,7 +6,6 @@ import (
 	"golang-rest-api-template/pkg/auth"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -16,14 +15,13 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-func TestMain(m *testing.M) {
+func init() {
 	if err := auth.SetJWTSigningKey(bytes.Repeat([]byte("m"), auth.MinJWTSecretKeyBytes)); err != nil {
 		panic(err)
 	}
 	if err := SetAPISecretKey(bytes.Repeat([]byte("x"), MinAPISecretKeyBytes)); err != nil {
 		panic(err)
 	}
-	os.Exit(m.Run())
 }
 
 func testRouterJWTAuthOnly(t *testing.T) *gin.Engine {


### PR DESCRIPTION
## Summary
- **pkg/api:** Move Gin + `SetJWTSigningKey` + `SetAPISecretKey` from `TestMain` into `init()` in `main_test.go`, and remove `TestMain` so a minimal `go test` file list that still includes `main_test.go` gets credentials before handler tests (e.g. login issuing JWTs).
- **pkg/auth:** Replace `TestMain` with `init()` for the default 32-byte test signing key so `go test auth_test.go auth.go` works without a separate `TestMain` file.
- **pkg/middleware:** Replace `TestMain` with `init()` for JWT + API secret used by `authenticateJWT_test.go` / `api_key_test.go`.

## Issue
Closes #112

Made with [Cursor](https://cursor.com)