### PR TITLE
fix(middleware): remove empty errors from access logger (#113)

### DIFF
--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -87,7 +87,6 @@ func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
 			zap.Duration("duration", duration),
 			zap.String("ip", c.ClientIP()),
 			zap.String("user-agent", c.Request.UserAgent()),
-			zap.String("errors", c.Errors.ByType(gin.ErrorTypePrivate).String()),
 			zap.String("request_id", requestID),
 		)
 
@@ -98,7 +97,6 @@ func Logger(logger *zap.Logger, collection *mongo.Collection) gin.HandlerFunc {
 			"duration":   duration,
 			"ip":         c.ClientIP(),
 			"user-agent": c.Request.UserAgent(),
-			"errors":     c.Errors.ByType(gin.ErrorTypePrivate).String(),
 			"request_id": requestID,
 		}
 


### PR DESCRIPTION
## Summary
Removes the `errors` field from structured request logs (zap and MongoDB) because nothing in the app uses `c.Error()` with `ErrorTypePrivate`, so the value was always empty.

## Issue
Closes #113

Made with [Cursor](https://cursor.com)