### PR TITLE
feat(database): Postgres connection pool from env (#126)

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"golang-rest-api-template/pkg/models"
@@ -13,6 +15,61 @@ import (
 )
 
 var sleep = time.Sleep
+
+const (
+	defaultPostgresMaxOpenConns    = 25
+	defaultPostgresMaxIdleConns    = 5
+	defaultPostgresConnMaxLifetime = time.Hour
+	defaultPostgresConnMaxIdleTime = 10 * time.Minute
+)
+
+func getenvPositiveInt(key string, def int) int {
+	s := strings.TrimSpace(os.Getenv(key))
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		log.Printf("database: invalid %s=%q, using default %d", key, s, def)
+		return def
+	}
+	return n
+}
+
+func getenvPositiveDuration(key string, def time.Duration) time.Duration {
+	s := strings.TrimSpace(os.Getenv(key))
+	if s == "" {
+		return def
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		log.Printf("database: invalid %s=%q, using default %v", key, s, def)
+		return def
+	}
+	return d
+}
+
+// configureConnPool applies *sql.DB pool settings from POSTGRES_* env vars (with
+// sane defaults). max idle connections is capped at max open.
+func configureConnPool(db *gorm.DB) error {
+	sqlDB, err := db.DB()
+	if err != nil {
+		return err
+	}
+	maxOpen := getenvPositiveInt("POSTGRES_MAX_OPEN_CONNS", defaultPostgresMaxOpenConns)
+	maxIdle := getenvPositiveInt("POSTGRES_MAX_IDLE_CONNS", defaultPostgresMaxIdleConns)
+	if maxIdle > maxOpen {
+		maxIdle = maxOpen
+	}
+	lifetime := getenvPositiveDuration("POSTGRES_CONN_MAX_LIFETIME", defaultPostgresConnMaxLifetime)
+	idleTime := getenvPositiveDuration("POSTGRES_CONN_MAX_IDLE_TIME", defaultPostgresConnMaxIdleTime)
+
+	sqlDB.SetMaxOpenConns(maxOpen)
+	sqlDB.SetMaxIdleConns(maxIdle)
+	sqlDB.SetConnMaxLifetime(lifetime)
+	sqlDB.SetConnMaxIdleTime(idleTime)
+	return nil
+}
 
 type Database interface {
 	Offset(offset int) *gorm.DB
@@ -82,6 +139,11 @@ func NewDatabase() *gorm.DB {
 
 	if err := database.AutoMigrate(&models.User{}); err != nil {
 		log.Printf("Failed to migrate User model: %v", err)
+		return nil
+	}
+
+	if err := configureConnPool(database); err != nil {
+		log.Printf("Failed to configure SQL connection pool: %v", err)
 		return nil
 	}
 

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -60,6 +60,25 @@ func TestGormDatabaseError(t *testing.T) {
 	assert.True(t, errors.Is(err, gorm.ErrRecordNotFound))
 }
 
+func TestConfigureConnPoolSQLite(t *testing.T) {
+	db := setupSQLiteDB(t)
+	assert.NoError(t, configureConnPool(db))
+}
+
+func TestGetenvPositiveInt(t *testing.T) {
+	t.Setenv("DATABASE_TEST_GETENV_INT", "42")
+	assert.Equal(t, 42, getenvPositiveInt("DATABASE_TEST_GETENV_INT", 1))
+	t.Setenv("DATABASE_TEST_GETENV_INT", "0")
+	assert.Equal(t, 99, getenvPositiveInt("DATABASE_TEST_GETENV_INT", 99))
+}
+
+func TestGetenvPositiveDuration(t *testing.T) {
+	t.Setenv("DATABASE_TEST_GETENV_DUR", "3m")
+	assert.Equal(t, 3*time.Minute, getenvPositiveDuration("DATABASE_TEST_GETENV_DUR", time.Second))
+	t.Setenv("DATABASE_TEST_GETENV_DUR", "not-a-duration")
+	assert.Equal(t, 5*time.Second, getenvPositiveDuration("DATABASE_TEST_GETENV_DUR", 5*time.Second))
+}
+
 func TestNewDatabaseInvalidPostgresEnv(t *testing.T) {
 	originalSleep := sleep
 	sleep = func(time.Duration) {}


### PR DESCRIPTION
## Summary
After a successful GORM open and AutoMigrate, configures the underlying `*sql.DB` pool using:

| Variable | Default |
|----------|---------|
| `POSTGRES_MAX_OPEN_CONNS` | 25 |
| `POSTGRES_MAX_IDLE_CONNS` | 5 (capped at max open) |
| `POSTGRES_CONN_MAX_LIFETIME` | `1h` |
| `POSTGRES_CONN_MAX_IDLE_TIME` | `10m` |

Non-positive or unparseable env values are logged and replaced with the default for that setting.

## Issue
Closes #126

Made with [Cursor](https://cursor.com)