### PR TITLE
test(e2e): require BASE_URL and API_KEY from env (#157)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,7 +28,7 @@ go test ./... -race
 # make up
 
 # optional: Python E2E (see README; requires BASE_URL and API_KEY)
-# pytest tests/
+# pytest -v tests/e2e.py
 ```
 
 ## Checklist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,8 @@ jobs:
         run: |
           set -euo pipefail
           set -a && . ./.env && set +a
-          export BASE_URL="${BASE_URL:-http://127.0.0.1:8001/api/v1}"
+          export BASE_URL="http://127.0.0.1:8001/api/v1"
+          export API_KEY="${API_SECRET_KEY}"
           pytest -v tests/e2e.py
 
       - name: Show service logs on failure

--- a/README.md
+++ b/README.md
@@ -214,19 +214,22 @@ pip install -r tests/requirements.txt
 
 #### 3. Set up the environment variables:
 
-E2E tests require `API_SECRET_KEY` (same value the API expects in `X-API-Key`). Optionally set `BASE_URL` (defaults to `http://127.0.0.1:8001/api/v1`).
+E2E tests read **`BASE_URL`** and **`API_KEY`** from the environment only (no baked-in defaults). `API_KEY` must match the value the API accepts in `X-API-Key` (for a Compose-backed local run, that is the same secret as `API_SECRET_KEY` in `.env`).
 
 With a project-root `.env` (as used by Docker Compose), load it before pytest:
 
 ```bash
 set -a && . ./.env && set +a
-export BASE_URL=http://127.0.0.1:8001/api/v1   # optional override
+export BASE_URL=http://127.0.0.1:8001/api/v1
+export API_KEY="$API_SECRET_KEY"
 pytest -v tests/e2e.py
 ```
 
 For a **staging** server, export the same variables with your deployment values.
 
 #### 4. Run the tests:
+
+After `BASE_URL` and `API_KEY` are set (see step 3):
 
 ```bash
 pytest -v tests/e2e.py

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -15,8 +15,8 @@ def _require_env(name: str) -> str:
     return v
 
 
-BASE_URL = os.environ.get("BASE_URL", "http://127.0.0.1:8001/api/v1").rstrip("/")
-API_KEY = _require_env("API_SECRET_KEY")
+BASE_URL = _require_env("BASE_URL").rstrip("/")
+API_KEY = _require_env("API_KEY")
 headers = {"X-API-Key": API_KEY, "Content-Type": "application/json"}
 
 


### PR DESCRIPTION
## Summary
- `tests/e2e.py`: require `BASE_URL` and `API_KEY` via existing `_require_env` helper (no default base URL; no reading `API_SECRET_KEY` inside the module).
- CI: after sourcing `.env`, export explicit `BASE_URL` and `API_KEY` (from `API_SECRET_KEY`) for pytest.
- README: document the two variables and local `export API_KEY="$API_SECRET_KEY"` pattern; clarify step 4 depends on step 3.
- PR template: point optional E2E command at `tests/e2e.py`.

Closes #157

Made with [Cursor](https://cursor.com)