### PR TITLE
ci: golangci-lint, govulncheck, mod tidy, cache, Codecov (#138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,47 @@ on:
       - "Makefile"
 
 jobs:
+  mod-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - name: Verify go.mod tidy
+        run: |
+          set -euo pipefail
+          go mod tidy
+          git diff --exit-code go.mod go.sum
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - name: Govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.5.0
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -29,12 +70,13 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache: true
 
       - name: Build
         run: go build -v ./...
 
   unit-test:
-    needs: [build]
+    needs: [build, lint, mod-tidy, govulncheck]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,9 +85,18 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache: true
 
-      - name: Unit tests
-        run: go test ./... -race
+      - name: Unit tests with coverage
+        run: go test ./pkg/... -race -coverprofile=coverage.out
+
+      - name: Upload coverage to Codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: false
 
   e2e:
     needs: [unit-test]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -37,7 +37,9 @@ func TestLoginHandlerSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.AutoMigrate(&models.User{})
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatal(err)
+	}
 
 	repo := NewUserRepository(&database.GormDatabase{DB: db})
 
@@ -109,7 +111,9 @@ func TestLoginHandlerUserNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.AutoMigrate(&models.User{})
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatal(err)
+	}
 
 	repo := NewUserRepository(&database.GormDatabase{DB: db})
 
@@ -135,7 +139,9 @@ func TestLoginHandlerWrongPassword(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.AutoMigrate(&models.User{})
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatal(err)
+	}
 
 	repo := NewUserRepository(&database.GormDatabase{DB: db})
 

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"errors"
-	"os"
 	"testing"
 	"time"
 
@@ -84,45 +83,11 @@ func TestNewDatabaseInvalidPostgresEnv(t *testing.T) {
 	sleep = func(time.Duration) {}
 	defer func() { sleep = originalSleep }()
 
-	oldHost, hadHost := os.LookupEnv("POSTGRES_HOST")
-	oldDB, hadDB := os.LookupEnv("POSTGRES_DB")
-	oldUser, hadUser := os.LookupEnv("POSTGRES_USER")
-	oldPass, hadPass := os.LookupEnv("POSTGRES_PASSWORD")
-	oldPort, hadPort := os.LookupEnv("POSTGRES_PORT")
-
-	defer func() {
-		if hadHost {
-			os.Setenv("POSTGRES_HOST", oldHost)
-		} else {
-			os.Unsetenv("POSTGRES_HOST")
-		}
-		if hadDB {
-			os.Setenv("POSTGRES_DB", oldDB)
-		} else {
-			os.Unsetenv("POSTGRES_DB")
-		}
-		if hadUser {
-			os.Setenv("POSTGRES_USER", oldUser)
-		} else {
-			os.Unsetenv("POSTGRES_USER")
-		}
-		if hadPass {
-			os.Setenv("POSTGRES_PASSWORD", oldPass)
-		} else {
-			os.Unsetenv("POSTGRES_PASSWORD")
-		}
-		if hadPort {
-			os.Setenv("POSTGRES_PORT", oldPort)
-		} else {
-			os.Unsetenv("POSTGRES_PORT")
-		}
-	}()
-
-	os.Setenv("POSTGRES_HOST", "127.0.0.1")
-	os.Setenv("POSTGRES_DB", "invalid_db")
-	os.Setenv("POSTGRES_USER", "invalid_user")
-	os.Setenv("POSTGRES_PASSWORD", "invalid_pass")
-	os.Setenv("POSTGRES_PORT", "1")
+	t.Setenv("POSTGRES_HOST", "127.0.0.1")
+	t.Setenv("POSTGRES_DB", "invalid_db")
+	t.Setenv("POSTGRES_USER", "invalid_user")
+	t.Setenv("POSTGRES_PASSWORD", "invalid_pass")
+	t.Setenv("POSTGRES_PORT", "1")
 
 	db := NewDatabase()
 	assert.Nil(t, db)


### PR DESCRIPTION
## Summary
- **mod-tidy** job: `go mod tidy` then `git diff --exit-code go.mod go.sum`.
- **govulncheck** job: `go run golang.org/x/vuln/cmd/govulncheck@latest ./...`.
- **lint** job: `golangci/golangci-lint-action` with **v2.5.0** and repo `.golangci.yml` (errcheck, govet, ineffassign, misspell, staticcheck).
- **build** / **unit-test**: `actions/setup-go` with **cache: true**; unit tests run `go test ./pkg/... -race -coverprofile=coverage.out` (coverage limited to `pkg` to avoid Go 1.25 `covdata` errors on no-test roots like `docs/`, `cmd/server`).
- **Codecov**: optional step when `secrets.CODECOV_TOKEN` is set; `fail_ci_if_error: false`.
- **unit-test** `needs`: build, lint, mod-tidy, govulncheck (e2e still after unit-test).

### Test / lint fixes
- `user_test.go`: check `AutoMigrate` errors.
- `db_test.go`: use `t.Setenv` for invalid Postgres env (drops manual defer + `os` import).

Closes #138

Made with [Cursor](https://cursor.com)