### PR TITLE
fix(docker): align EXPOSE, healthcheck, build context (#135)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Git and local env
+.git
+.gitignore
+.env
+.env.*
+
+# Local DB data and caches (never belong in the image build context)
+.dbdata
+**/.dbdata
+
+# Coverage / IDE
+coverage.out
+coverage.html
+.cursor
+.idea
+.vscode
+
+# Python (e2e / tooling)
+__pycache__
+.pytest_cache
+.venv
+venv
+
+# Vendored deps — image uses `go mod download` in the builder stage
+vendor/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ FROM debian:bookworm-slim AS runtime
 
 WORKDIR /app
 
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates curl \
+	&& rm -rf /var/lib/apt/lists/*
+
 RUN useradd --system --no-create-home --uid 10001 appuser
 
 COPY --from=builder /out/server /app/server
@@ -29,6 +33,9 @@ ENV GIN_MODE=release
 
 USER appuser
 
-EXPOSE 8080
+EXPOSE 8001
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+	CMD curl -fsS http://127.0.0.1:8001/api/v1/ >/dev/null || exit 1
 
 CMD ["/app/server"]


### PR DESCRIPTION
## Summary
- **EXPOSE 8001** to match `cmd/server/main.go` (`:8001`); Compose already published `8001:8001`.
- **Runtime stage**: install `ca-certificates` + `curl`; **HEALTHCHECK** curls `http://127.0.0.1:8001/api/v1/` (unauthenticated `Healthcheck` route).
- **`.dockerignore`**: shrink/sanitize context — `vendor/`, `.dbdata`, `.env*`, coverage artifacts, IDE/Python junk, `.git`.

`docker build` verified locally.

Closes #135

Made with [Cursor](https://cursor.com)