### PR TITLE
chore(compose): pin images, localhost binds, Postgres volume (#136)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,5 @@ clean:
 	docker rm dockerPostgres
 	docker rm dockerRedis
 	docker image rm golang-rest-api-template-backend
+	# Legacy bind-mount dir (Compose now uses named volume postgres_data).
 	rm -rf .dbdata

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ To generate URL-safe random values for `JWT_SECRET_KEY` and `API_SECRET_KEY`, ru
 go run ./scripts/generate_key.go
 ```
 
-`docker-compose.yml` does **not** embed JWT or API secrets; they must come from `.env` or your shell environment so keys are not committed to the repository. The Compose file sets **`GIN_MODE=release`** for the API service so production-style security headers apply; override in `.env` if you need `debug` locally.
+`docker-compose.yml` does **not** embed JWT or API secrets; they must come from `.env` or your shell environment so keys are not committed to the repository. The Compose file sets **`GIN_MODE=release`** for the API service so production-style security headers apply; override in `.env` if you need `debug` locally. Service images use **pinned tags** (Postgres, Redis, Mongo), **published ports bind to `127.0.0.1`** for local dev, and Postgres data uses a **named volume** (`postgres_data`, same pattern as `mongo_data`). Remove volumes with `docker compose down -v` when you want a fresh database.
 
 ### API Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - 8001:8001
+      - "127.0.0.1:8001:8001"
     depends_on:
       db:
         condition: service_healthy
@@ -28,14 +28,14 @@ services:
       GIN_MODE: release
 
   db:
-    image: postgres:14.1-alpine
+    image: postgres:14.17-alpine
     restart: always
     container_name: dockerPostgres
     volumes:
-      # Official postgres image stores cluster data under PGDATA (default /var/lib/postgresql/data).
-      - .dbdata:/var/lib/postgresql/data
+      # Named volume (aligned with mongo_data); avoids bind-mounting ./.dbdata into the image context.
+      - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5435:5435"
+      - "127.0.0.1:5435:5435"
     environment:
       - POSTGRES_DB=go_app_dev
       - POSTGRES_USER=docker
@@ -49,9 +49,9 @@ services:
       start_period: 10s
 
   redis:
-    image: "redis:alpine"
+    image: redis:7.4.2-alpine
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     container_name: dockerRedis
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -61,12 +61,12 @@ services:
       start_period: 5s
 
   mongo:
-    image: mongo
+    image: mongo:7.0.15
     container_name: dockerMongo
     volumes:
       - mongo_data:/data/db
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     restart: always
     healthcheck:
       test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
@@ -76,4 +76,5 @@ services:
       start_period: 10s
 
 volumes:
-  mongo_data: # Declare the volume for MongoDB data
+  mongo_data:
+  postgres_data:


### PR DESCRIPTION
## Summary
- **Images**: `postgres:14.17-alpine`, `redis:7.4.2-alpine`, `mongo:7.0.15` (replace floating `mongo` / `redis:alpine`; bump Postgres patch).
- **Ports**: publish **8001**, **5435**, **6379**, **27017** on **`127.0.0.1`** only.
- **Volumes**: Postgres uses **named volume `postgres_data`** (same idea as `mongo_data`); removes `./.dbdata` bind mount from Compose.
- **README**: short note on pins, bindings, volumes, and `docker compose down -v` for a reset.
- **Makefile** `clean`: comment that `.dbdata` is legacy cleanup.

Closes #136

Made with [Cursor](https://cursor.com)