### PR TITLE
feat(api): /livez and /readyz probes (#142)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           set -euo pipefail
           for i in $(seq 1 60); do
-            if curl -sfS "http://127.0.0.1:8001/api/v1/" >/dev/null; then
+            if curl -sfS "http://127.0.0.1:8001/readyz" >/dev/null; then
               echo "API ready after ${i} attempt(s)"
               exit 0
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ USER appuser
 EXPOSE 8001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-	CMD curl -fsS http://127.0.0.1:8001/api/v1/ >/dev/null || exit 1
+	CMD curl -fsS http://127.0.0.1:8001/livez >/dev/null || exit 1
 
 CMD ["/app/server"]

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ golang-rest-api-template/
 │  │  ├── books_test.go
 │  │  ├── book_routes_auth_test.go
 │  │  ├── main_test.go
+│  │  ├── probes.go
+│  │  ├── probes_test.go
 │  │  ├── router.go
 │  │  ├── router_trusted_proxies_test.go
 │  │  ├── user.go
@@ -176,7 +178,9 @@ http://localhost:8001/swagger/index.html
 
 ### Endpoints
 
-- `GET /api/v1/`: Health check (no `X-API-Key`; same path CI uses for readiness).
+- `GET /livez`: Liveness probe (process up; no dependency checks; no `X-API-Key`).
+- `GET /readyz`: Readiness probe (checks Postgres, Redis, Mongo; **503** if a dependency fails; no `X-API-Key`). Docker image `HEALTHCHECK` uses **`/livez`** so the container stays alive while dependencies recover.
+- `GET /api/v1/`: Health check (no `X-API-Key`; lightweight app-level ping).
 - `GET /api/v1/books`: Get all books.
 - `GET /api/v1/books/:id`: Get a single book by ID.
 - `POST /api/v1/books`: Create a new book.

--- a/pkg/api/probes.go
+++ b/pkg/api/probes.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/database"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-redis/redis/v8"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+// registerProbeRoutes mounts Kubernetes-style liveness and readiness endpoints.
+// They are registered before request logging, rate limiting, and the /api/v1
+// group so orchestrators can probe without API keys or JWTs.
+func registerProbeRoutes(r *gin.Engine, db database.Database, redisClient cache.Cache, mongoCol *mongo.Collection) {
+	r.GET("/livez", livez)
+	r.GET("/readyz", readyzHandler(db, redisClient, mongoCol))
+}
+
+func livez(c *gin.Context) {
+	c.Status(http.StatusOK)
+}
+
+func readyzHandler(db database.Database, redisClient cache.Cache, mongoCol *mongo.Collection) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Second)
+		defer cancel()
+
+		if err := pingPostgres(ctx, db); err != nil {
+			c.String(http.StatusServiceUnavailable, "postgres: %v", err)
+			return
+		}
+		if err := pingRedis(ctx, redisClient); err != nil {
+			c.String(http.StatusServiceUnavailable, "redis: %v", err)
+			return
+		}
+		if err := pingMongo(ctx, mongoCol); err != nil {
+			c.String(http.StatusServiceUnavailable, "mongo: %v", err)
+			return
+		}
+		c.Status(http.StatusOK)
+	}
+}
+
+func pingPostgres(ctx context.Context, db database.Database) error {
+	gdb, ok := db.(*database.GormDatabase)
+	if !ok || gdb == nil || gdb.DB == nil {
+		return errors.New("database not configured")
+	}
+	sqlDB, err := gdb.DB.DB()
+	if err != nil {
+		return err
+	}
+	return sqlDB.PingContext(ctx)
+}
+
+// redisPinger matches *redis.Client without importing the concrete type in Cache.
+type redisPinger interface {
+	Ping(ctx context.Context) *redis.StatusCmd
+}
+
+func pingRedis(ctx context.Context, c cache.Cache) error {
+	if c == nil {
+		return errors.New("redis not configured")
+	}
+	p, ok := c.(redisPinger)
+	if !ok {
+		return errors.New("redis client type does not support ping")
+	}
+	if err := p.Ping(ctx).Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func pingMongo(ctx context.Context, col *mongo.Collection) error {
+	if col == nil {
+		return errors.New("mongo collection not configured")
+	}
+	client := col.Database().Client()
+	if client == nil {
+		return fmt.Errorf("mongo client nil")
+	}
+	return client.Ping(ctx, readpref.Primary())
+}

--- a/pkg/api/probes_test.go
+++ b/pkg/api/probes_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLivez(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/livez", livez)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/livez", nil)
+	r.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestPingPostgresNilDB(t *testing.T) {
+	err := pingPostgres(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestPingRedisNilClient(t *testing.T) {
+	err := pingRedis(context.Background(), nil)
+	assert.Error(t, err)
+}
+
+func TestPingMongoNilCollection(t *testing.T) {
+	err := pingMongo(context.Background(), nil)
+	assert.Error(t, err)
+}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -29,6 +29,8 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db databas
 	if err := configureTrustedProxies(r); err != nil {
 		panic("api: trusted proxies: " + err.Error())
 	}
+	registerProbeRoutes(r, db, redisClient, mongoCollection)
+
 	r.Use(middleware.MaxRequestBody(maxRequestBodyBytesFromEnv()))
 	r.Use(middleware.RequestID())
 


### PR DESCRIPTION
## Summary

- **GET /livez**: liveness — HTTP **200** if the process serves requests (no Postgres/Redis/Mongo checks).
- **GET /readyz**: readiness — **200** only if Postgres (`PingContext` on `*sql.DB`), Redis (`Ping`), and Mongo (`Client.Ping`) succeed within **2s**; otherwise **503** with a short text body (`postgres:`, `redis:`, or `mongo:` prefix).
- Routes are registered **before** `MaxRequestBody`, access logging, rate limiting, and `/api/v1` — **no API key**.
- **Dockerfile** `HEALTHCHECK` curls **/livez** (container liveness without dependency checks each interval).
- **CI** “wait for API” curls **/readyz** so e2e starts only when the app sees healthy dependencies.
- **README**: probe docs + folder tree entries for `probes.go` / `probes_test.go`.
- **Tests**: `TestLivez` plus nil-dependency helper tests.

Closes #142
