### PR TITLE
refactor: handler / service / repository split (closes #114)

### DIFF
--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -1,56 +1,26 @@
 package api
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"golang-rest-api-template/pkg/cache"
-	"golang-rest-api-template/pkg/database"
-	"golang-rest-api-template/pkg/models"
 	"net/http"
 	"strconv"
 	"strings"
-	"time"
+
+	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/database"
+	"golang-rest-api-template/pkg/models"
+	"golang-rest-api-template/pkg/repository"
+	"golang-rest-api-template/pkg/service"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/sync/singleflight"
 )
-
-// booksListCacheGenKey is incremented on book writes so list pagination entries
-// (scoped by generation) go stale without Redis KEYS.
-const booksListCacheGenKey = "v1:books:list_cache_gen"
 
 const (
 	findBooksMinLimit = 1
 	findBooksMaxLimit = 100
 )
 
-func booksListDataCacheKey(gen int64, offset, limit int) string {
-	return fmt.Sprintf("books_g%d_offset_%d_limit_%d", gen, offset, limit)
-}
-
-func (r *bookRepository) booksListCacheGeneration(ctx context.Context) int64 {
-	if r == nil || r.RedisClient == nil {
-		return 0
-	}
-	n, err := r.RedisClient.Get(ctx, booksListCacheGenKey).Int64()
-	if err != nil {
-		return 0
-	}
-	if n < 0 {
-		return 0
-	}
-	return n
-}
-
-func (r *bookRepository) bumpBooksListCacheGeneration(ctx context.Context) {
-	if r == nil || r.RedisClient == nil {
-		return
-	}
-	_, _ = r.RedisClient.Incr(ctx, booksListCacheGenKey).Result()
-}
-
+// BookRepository is the HTTP surface for book routes (Gin handlers).
 type BookRepository interface {
 	Healthcheck(c *gin.Context)
 	FindBooks(c *gin.Context)
@@ -58,6 +28,16 @@ type BookRepository interface {
 	FindBook(c *gin.Context)
 	UpdateBook(c *gin.Context)
 	DeleteBook(c *gin.Context)
+}
+
+type bookRepository struct {
+	svc *service.BookService
+}
+
+// NewBookRepository wires persistence and cache into book HTTP handlers.
+func NewBookRepository(db database.Database, redisClient cache.Cache) *bookRepository {
+	store := repository.NewGormBookStore(db)
+	return &bookRepository{svc: service.NewBookService(store, redisClient)}
 }
 
 func parseIDParam(c *gin.Context) (uint, bool) {
@@ -73,26 +53,32 @@ func parseIDParam(c *gin.Context) (uint, bool) {
 	return uint(id), true
 }
 
-// Sentinel errors for FindBooks singleflight so callers can map failures to HTTP responses.
-var (
-	errListBooksSFDB      = errors.New("listBooks singleflight: database")
-	errListBooksSFMarshal = errors.New("listBooks singleflight: marshal")
-	errListBooksSFRedis   = errors.New("listBooks singleflight: redis set")
-)
+func parseOffsetLimit(c *gin.Context) (offset, limit int, ok bool) {
+	offsetQuery := strings.TrimSpace(c.DefaultQuery("offset", "0"))
+	limitQuery := strings.TrimSpace(c.DefaultQuery("limit", "10"))
 
-// bookRepository holds shared resources like database and Redis client
-type bookRepository struct {
-	DB          database.Database
-	RedisClient cache.Cache
-	listBooksSF singleflight.Group
-}
-
-// NewBookRepository returns a bookRepository backed by db and optional redisClient.
-func NewBookRepository(db database.Database, redisClient cache.Cache) *bookRepository {
-	return &bookRepository{
-		DB:          db,
-		RedisClient: redisClient,
+	o, err := strconv.Atoi(offsetQuery)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid offset format"})
+		return 0, 0, false
 	}
+	l, err := strconv.Atoi(limitQuery)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid limit format"})
+		return 0, 0, false
+	}
+	if o < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be >= 0"})
+		return 0, 0, false
+	}
+	if l < findBooksMinLimit {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be at least 1"})
+		return 0, 0, false
+	}
+	if l > findBooksMaxLimit {
+		l = findBooksMaxLimit
+	}
+	return o, l, true
 }
 
 // @BasePath /api/v1
@@ -123,82 +109,26 @@ func (r *bookRepository) Healthcheck(c *gin.Context) {
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books [get]
 func (r *bookRepository) FindBooks(c *gin.Context) {
-	var books []models.Book
-
-	// Query params trimmed so cache keys match parsed integers (no cache fragmentation from " 0 " vs "0").
-	offsetQuery := strings.TrimSpace(c.DefaultQuery("offset", "0"))
-	limitQuery := strings.TrimSpace(c.DefaultQuery("limit", "10"))
-
-	offset, err := strconv.Atoi(offsetQuery)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid offset format"})
+	offset, limit, ok := parseOffsetLimit(c)
+	if !ok {
 		return
 	}
-
-	limit, err := strconv.Atoi(limitQuery)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid limit format"})
-		return
-	}
-
-	if offset < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be >= 0"})
-		return
-	}
-	if limit < findBooksMinLimit {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be at least 1"})
-		return
-	}
-	if limit > findBooksMaxLimit {
-		limit = findBooksMaxLimit
-	}
-
-	reqCtx := c.Request.Context()
-	gen := r.booksListCacheGeneration(reqCtx)
-	cacheKey := booksListDataCacheKey(gen, offset, limit)
-
-	// Try fetching the data from Redis first
-	cachedBooks, err := r.RedisClient.Get(reqCtx, cacheKey).Result()
-	if err == nil {
-		err := json.Unmarshal([]byte(cachedBooks), &books)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to unmarshal cached data"})
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"data": books})
-		return
-	}
-
-	// If cache missed, coalesce concurrent loads on the same cache key (cache stampede protection).
-	out, err, _ := r.listBooksSF.Do(cacheKey, func() (interface{}, error) {
-		var loaded []models.Book
-		if err := r.DB.Offset(offset).Limit(limit).Find(&loaded).Error; err != nil {
-			return nil, fmt.Errorf("%w: %v", errListBooksSFDB, err)
-		}
-		serializedBooks, err := json.Marshal(loaded)
-		if err != nil {
-			return nil, fmt.Errorf("%w: %v", errListBooksSFMarshal, err)
-		}
-		if err := r.RedisClient.Set(reqCtx, cacheKey, serializedBooks, time.Minute).Err(); err != nil {
-			return nil, fmt.Errorf("%w: %v", errListBooksSFRedis, err)
-		}
-		return loaded, nil
-	})
+	books, err := r.svc.ListBooks(c.Request.Context(), offset, limit)
 	if err != nil {
 		switch {
-		case errors.Is(err, errListBooksSFDB):
+		case errors.Is(err, service.ErrListBooksDB):
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
-		case errors.Is(err, errListBooksSFMarshal):
+		case errors.Is(err, service.ErrListBooksMarshal):
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal data"})
-		case errors.Is(err, errListBooksSFRedis):
+		case errors.Is(err, service.ErrListBooksRedis):
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set cache"})
+		case errors.Is(err, service.ErrListBooksUnmarshal):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to unmarshal cached data"})
 		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
 		}
 		return
 	}
-
-	books = out.([]models.Book)
 	c.JSON(http.StatusOK, gin.H{"data": books})
 }
 
@@ -218,21 +148,15 @@ func (r *bookRepository) FindBooks(c *gin.Context) {
 // @Router /books [post]
 func (r *bookRepository) CreateBook(c *gin.Context) {
 	var input models.CreateBook
-
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	book := models.Book{Title: input.Title, Author: input.Author}
-
-	if err := r.DB.Create(&book).Error; err != nil {
+	book, err := r.svc.CreateBook(c.Request.Context(), input.Title, input.Author)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book"})
 		return
 	}
-
-	r.bumpBooksListCacheGeneration(c.Request.Context())
-
 	c.JSON(http.StatusCreated, gin.H{"data": book})
 }
 
@@ -247,18 +171,19 @@ func (r *bookRepository) CreateBook(c *gin.Context) {
 // @Failure 404 {string} string "Book not found"
 // @Router /books/{id} [get]
 func (r *bookRepository) FindBook(c *gin.Context) {
-	var book models.Book
-
 	id, ok := parseIDParam(c)
 	if !ok {
 		return
 	}
-
-	if err := r.DB.FirstByID(&book, id).Error(); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+	book, err := r.svc.GetBook(c.Request.Context(), id)
+	if err != nil {
+		if repository.IsBookNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load book"})
 		return
 	}
-
 	c.JSON(http.StatusOK, gin.H{"data": book})
 }
 
@@ -279,31 +204,24 @@ func (r *bookRepository) FindBook(c *gin.Context) {
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books/{id} [put]
 func (r *bookRepository) UpdateBook(c *gin.Context) {
-	var book models.Book
 	var input models.UpdateBook
-
 	id, ok := parseIDParam(c)
 	if !ok {
 		return
 	}
-
-	if err := r.DB.FirstByID(&book, id).Error(); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
-		return
-	}
-
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	if err := r.DB.Model(&book).Updates(models.Book{Title: input.Title, Author: input.Author}).Error; err != nil {
+	book, err := r.svc.UpdateBook(c.Request.Context(), id, input.Title, input.Author)
+	if err != nil {
+		if repository.IsBookNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update book"})
 		return
 	}
-
-	r.bumpBooksListCacheGeneration(c.Request.Context())
-
 	c.JSON(http.StatusOK, gin.H{"data": book})
 }
 
@@ -321,24 +239,17 @@ func (r *bookRepository) UpdateBook(c *gin.Context) {
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books/{id} [delete]
 func (r *bookRepository) DeleteBook(c *gin.Context) {
-	var book models.Book
-
 	id, ok := parseIDParam(c)
 	if !ok {
 		return
 	}
-
-	if err := r.DB.FirstByID(&book, id).Error(); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
-		return
-	}
-
-	if err := r.DB.Delete(&book).Error; err != nil {
+	if err := r.svc.DeleteBook(c.Request.Context(), id); err != nil {
+		if repository.IsBookNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete book"})
 		return
 	}
-
-	r.bumpBooksListCacheGeneration(c.Request.Context())
-
 	c.Status(http.StatusNoContent)
 }

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -8,6 +8,7 @@ import (
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/database"
 	"golang-rest-api-template/pkg/models"
+	"golang-rest-api-template/pkg/service"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -37,8 +38,6 @@ func TestNewBookRepository(t *testing.T) {
 	repo := NewBookRepository(mockDB, mockCache)
 
 	assert.NotNil(t, repo, "NewBookRepository should return a non-nil instance of bookRepository")
-	assert.Equal(t, mockDB, repo.DB, "DB should be set to the mock database instance")
-	assert.Equal(t, mockCache, repo.RedisClient, "RedisClient should be set to the mock cache instance")
 }
 
 func TestHealthcheck(t *testing.T) {
@@ -172,10 +171,10 @@ func TestFindBooksLimitCappedAtMax(t *testing.T) {
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
 	gomock.InOrder(
-		mockCache.EXPECT().Get(gomock.Any(), booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
-		mockCache.EXPECT().Get(gomock.Any(), booksListDataCacheKey(0, 0, findBooksMaxLimit)).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), service.BooksListDataCacheKey(0, 0, findBooksMaxLimit)).Return(redis.NewStringResult("", redis.Nil)),
 	)
-	mockCache.EXPECT().Set(gomock.Any(), booksListDataCacheKey(0, 0, findBooksMaxLimit), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
+	mockCache.EXPECT().Set(gomock.Any(), service.BooksListDataCacheKey(0, 0, findBooksMaxLimit), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -265,7 +264,7 @@ func TestCreateBookCacheIncrError(t *testing.T) {
 	requestBody, _ := json.Marshal(inputBook)
 
 	mockDB.EXPECT().Create(gomock.Any()).Return(&gorm.DB{Error: nil})
-	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(0, errors.New("incr error")))
+	mockCache.EXPECT().Incr(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewIntResult(0, errors.New("incr error")))
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
@@ -339,14 +338,6 @@ func TestUpdateBookBindError(t *testing.T) {
 	r := gin.Default()
 	r.PUT("/book/:id", repo.UpdateBook)
 
-	existingBook := models.Book{ID: 1, Title: "Old Title", Author: "Old Author"}
-
-	mockDB.EXPECT().FirstByID(gomock.Any(), uint(1)).DoAndReturn(func(dest interface{}, id uint) database.Database {
-		*dest.(*models.Book) = existingBook
-		return mockDB
-	})
-	mockDB.EXPECT().Error().Return(nil)
-
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("PUT", "/book/1", bytes.NewBufferString("invalid json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -386,8 +377,8 @@ func TestFindBooksDatabaseError(t *testing.T) {
 	r.GET("/books", repo.FindBooks)
 
 	gomock.InOrder(
-		mockCache.EXPECT().Get(gomock.Any(), booksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
-		mockCache.EXPECT().Get(gomock.Any(), booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), service.BooksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
 	)
 
 	w := httptest.NewRecorder()
@@ -460,7 +451,7 @@ func TestUpdateBookBumpsListCacheGen(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockCache := cache.NewMockCache(ctrl)
-	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+	mockCache.EXPECT().Incr(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
 
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 	gin.SetMode(gin.TestMode)
@@ -495,7 +486,7 @@ func TestDeleteBookBumpsListCacheGen(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockCache := cache.NewMockCache(ctrl)
-	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+	mockCache.EXPECT().Incr(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
 
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 	gin.SetMode(gin.TestMode)
@@ -571,10 +562,10 @@ func TestFindBooks(t *testing.T) {
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
 	gomock.InOrder(
-		mockCache.EXPECT().Get(gomock.Any(), booksListCacheGenKey).Return(redis.NewStringResult("0", nil)),
-		mockCache.EXPECT().Get(gomock.Any(), booksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
+		mockCache.EXPECT().Get(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewStringResult("0", nil)),
+		mockCache.EXPECT().Get(gomock.Any(), service.BooksListDataCacheKey(0, 0, 10)).Return(redis.NewStringResult("", redis.Nil)),
 	)
-	mockCache.EXPECT().Set(gomock.Any(), booksListDataCacheKey(0, 0, 10), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
+	mockCache.EXPECT().Set(gomock.Any(), service.BooksListDataCacheKey(0, 0, 10), gomock.Any(), time.Minute).Return(redis.NewStatusResult("OK", nil)).Times(1)
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
@@ -615,7 +606,7 @@ func TestCreateBook(t *testing.T) {
 		return &gorm.DB{Error: nil}
 	})
 
-	mockCache.EXPECT().Incr(gomock.Any(), booksListCacheGenKey).Return(redis.NewIntResult(1, nil))
+	mockCache.EXPECT().Incr(gomock.Any(), service.BooksListCacheGenKey).Return(redis.NewIntResult(1, nil))
 
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", "/books", bytes.NewBuffer(requestBody))
@@ -844,12 +835,12 @@ func TestFindBooksSingleflightCoalescesDB(t *testing.T) {
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
 	const n = 50
-	dataKey := booksListDataCacheKey(0, 0, 10)
+	dataKey := service.BooksListDataCacheKey(0, 0, 10)
 	var cacheMu sync.Mutex
 	var cachedPayload string
 	mockCache.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
 		switch key {
-		case booksListCacheGenKey:
+		case service.BooksListCacheGenKey:
 			return redis.NewStringResult("", redis.Nil)
 		case dataKey:
 			cacheMu.Lock()
@@ -937,12 +928,12 @@ func TestFindBooksLeadingZerosShareListCache(t *testing.T) {
 	mockCache := cache.NewMockCache(ctrl)
 	repo := NewBookRepository(&database.GormDatabase{DB: db}, mockCache)
 
-	dataKey := booksListDataCacheKey(0, 0, 10)
+	dataKey := service.BooksListDataCacheKey(0, 0, 10)
 	var cacheMu sync.Mutex
 	var cachedPayload string
 	mockCache.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, key string) *redis.StringCmd {
 		switch key {
-		case booksListCacheGenKey:
+		case service.BooksListCacheGenKey:
 			return redis.NewStringResult("", redis.Nil)
 		case dataKey:
 			cacheMu.Lock()

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -2,48 +2,30 @@ package api
 
 import (
 	"errors"
-	"golang-rest-api-template/pkg/auth"
+	"net/http"
+
 	"golang-rest-api-template/pkg/database"
 	"golang-rest-api-template/pkg/models"
-	"net/http"
-	"strings"
-
-	"gorm.io/gorm"
+	"golang-rest-api-template/pkg/repository"
+	"golang-rest-api-template/pkg/service"
 
 	"github.com/gin-gonic/gin"
-	"golang.org/x/crypto/bcrypt"
 )
 
+// UserRepository is the HTTP surface for auth routes (Gin handlers).
 type UserRepository interface {
 	LoginHandler(c *gin.Context)
 	RegisterHandler(c *gin.Context)
 }
 
 type userRepository struct {
-	DB database.Database
+	svc *service.UserService
 }
 
-// registerUsernameConflict detects unique violations on user registration.
-// Prefer gorm.ErrDuplicatedKey; fall back to driver strings when translation is missing.
-func registerUsernameConflict(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, gorm.ErrDuplicatedKey) {
-		return true
-	}
-	s := strings.ToLower(err.Error())
-	if strings.Contains(s, "unique constraint failed") {
-		return true
-	}
-	if strings.Contains(s, "duplicate key") && strings.Contains(s, "unique") {
-		return true
-	}
-	return false
-}
-
+// NewUserRepository wires persistence into user HTTP handlers.
 func NewUserRepository(db database.Database) *userRepository {
-	return &userRepository{DB: db}
+	store := repository.NewGormUserStore(db)
+	return &userRepository{svc: service.NewUserService(store)}
 }
 
 // @BasePath /api/v1
@@ -64,34 +46,22 @@ func NewUserRepository(db database.Database) *userRepository {
 // @Router /login [post]
 func (r *userRepository) LoginHandler(c *gin.Context) {
 	var incoming models.LoginUser
-	var dbUser models.User
-
 	if err := c.ShouldBindJSON(&incoming); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	if err := r.DB.Where("username = ?", incoming.Username).First(&dbUser).Error(); err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+	token, err := r.svc.Login(c.Request.Context(), incoming.Username, incoming.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrInvalidLogin):
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid username or password"})
-		} else {
+		case errors.Is(err, service.ErrLoginDB), errors.Is(err, service.ErrTokenGenerate):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
+		default:
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
 		}
 		return
 	}
-
-	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(incoming.Password)); err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid username or password"})
-		return
-	}
-
-	// Generate JWT token
-	token, err := auth.GenerateToken(dbUser.Username)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Error generating token"})
-		return
-	}
-
 	c.JSON(http.StatusOK, gin.H{"token": token})
 }
 
@@ -111,31 +81,20 @@ func (r *userRepository) LoginHandler(c *gin.Context) {
 // @Router /register [post]
 func (r *userRepository) RegisterHandler(c *gin.Context) {
 	var user models.LoginUser
-
 	if err := c.ShouldBindJSON(&user); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-
-	// Hash the password
-	hashedPassword, err := auth.HashPassword(user.Password)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not hash password"})
-		return
-	}
-
-	// Create new user
-	newUser := models.User{Username: user.Username, Password: hashedPassword}
-
-	// Save the user to the database
-	if err := r.DB.Create(&newUser).Error; err != nil {
-		if registerUsernameConflict(err) {
+	if err := r.svc.Register(c.Request.Context(), user.Username, user.Password); err != nil {
+		switch {
+		case errors.Is(err, service.ErrRegisterConflict):
 			c.JSON(http.StatusConflict, gin.H{"error": "username already taken"})
-			return
+		case errors.Is(err, service.ErrRegisterHash), errors.Is(err, service.ErrRegisterSave):
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not save user"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not save user"})
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not save user"})
 		return
 	}
-
 	c.JSON(http.StatusCreated, gin.H{"message": "Registration successful"})
 }

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -28,7 +28,6 @@ func TestNewUserRepository(t *testing.T) {
 	repo := NewUserRepository(mockDB)
 
 	assert.NotNil(t, repo, "NewUserRepository should return a non-nil instance of userRepository")
-	assert.Equal(t, mockDB, repo.DB, "DB should be set to the mock database instance")
 }
 
 func TestLoginHandlerSuccess(t *testing.T) {

--- a/pkg/repository/book.go
+++ b/pkg/repository/book.go
@@ -1,0 +1,12 @@
+package repository
+
+import "golang-rest-api-template/pkg/models"
+
+// BookPersistence is persistence for books without HTTP or Gin.
+type BookPersistence interface {
+	List(offset, limit int) ([]models.Book, error)
+	Create(book *models.Book) error
+	FirstByID(id uint) (*models.Book, error)
+	UpdateFields(id uint, title, author string) (*models.Book, error)
+	DeleteByID(id uint) error
+}

--- a/pkg/repository/book_gorm.go
+++ b/pkg/repository/book_gorm.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"errors"
+
+	"golang-rest-api-template/pkg/database"
+	"golang-rest-api-template/pkg/models"
+
+	"gorm.io/gorm"
+)
+
+// GormBookStore implements BookPersistence using database.Database (GORM).
+type GormBookStore struct {
+	db database.Database
+}
+
+// NewGormBookStore returns a BookPersistence backed by db.
+func NewGormBookStore(db database.Database) *GormBookStore {
+	return &GormBookStore{db: db}
+}
+
+func (s *GormBookStore) List(offset, limit int) ([]models.Book, error) {
+	var out []models.Book
+	err := s.db.Offset(offset).Limit(limit).Find(&out).Error
+	return out, err
+}
+
+func (s *GormBookStore) Create(book *models.Book) error {
+	return s.db.Create(book).Error
+}
+
+func (s *GormBookStore) FirstByID(id uint) (*models.Book, error) {
+	var book models.Book
+	if err := s.db.FirstByID(&book, id).Error(); err != nil {
+		return nil, err
+	}
+	return &book, nil
+}
+
+func (s *GormBookStore) UpdateFields(id uint, title, author string) (*models.Book, error) {
+	book, err := s.FirstByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.db.Model(book).Updates(models.Book{Title: title, Author: author}).Error; err != nil {
+		return nil, err
+	}
+	book.Title = title
+	book.Author = author
+	return book, nil
+}
+
+func (s *GormBookStore) DeleteByID(id uint) error {
+	book, err := s.FirstByID(id)
+	if err != nil {
+		return err
+	}
+	return s.db.Delete(book).Error
+}
+
+// IsBookNotFound reports whether err is a missing-book lookup from GORM.
+func IsBookNotFound(err error) bool {
+	return errors.Is(err, gorm.ErrRecordNotFound)
+}

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+func TestIsBookNotFound(t *testing.T) {
+	assert.True(t, IsBookNotFound(gorm.ErrRecordNotFound))
+	assert.False(t, IsBookNotFound(nil))
+	assert.False(t, IsBookNotFound(errors.New("other")))
+	assert.True(t, IsBookNotFound(errors.Join(gorm.ErrRecordNotFound, errors.New("wrap"))))
+}
+
+func TestIsUserNotFound(t *testing.T) {
+	assert.True(t, IsUserNotFound(gorm.ErrRecordNotFound))
+	assert.False(t, IsUserNotFound(nil))
+	assert.False(t, IsUserNotFound(errors.New("other")))
+	assert.True(t, IsUserNotFound(errors.Join(gorm.ErrRecordNotFound, errors.New("wrap"))))
+}

--- a/pkg/repository/user.go
+++ b/pkg/repository/user.go
@@ -1,0 +1,9 @@
+package repository
+
+import "golang-rest-api-template/pkg/models"
+
+// UserPersistence loads and stores users without HTTP or Gin.
+type UserPersistence interface {
+	FindByUsername(username string) (*models.User, error)
+	Create(user *models.User) error
+}

--- a/pkg/repository/user_gorm.go
+++ b/pkg/repository/user_gorm.go
@@ -1,0 +1,37 @@
+package repository
+
+import (
+	"errors"
+
+	"golang-rest-api-template/pkg/database"
+	"golang-rest-api-template/pkg/models"
+
+	"gorm.io/gorm"
+)
+
+// GormUserStore implements UserPersistence using database.Database (GORM).
+type GormUserStore struct {
+	db database.Database
+}
+
+// NewGormUserStore returns a UserPersistence backed by db.
+func NewGormUserStore(db database.Database) *GormUserStore {
+	return &GormUserStore{db: db}
+}
+
+func (s *GormUserStore) FindByUsername(username string) (*models.User, error) {
+	var u models.User
+	if err := s.db.Where("username = ?", username).First(&u).Error(); err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (s *GormUserStore) Create(user *models.User) error {
+	return s.db.Create(user).Error
+}
+
+// IsUserNotFound reports whether err is a missing-user lookup from GORM.
+func IsUserNotFound(err error) bool {
+	return errors.Is(err, gorm.ErrRecordNotFound)
+}

--- a/pkg/service/book_service.go
+++ b/pkg/service/book_service.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/models"
+	"golang-rest-api-template/pkg/repository"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// BooksListCacheGenKey is the Redis key for the books list cache generation counter.
+const BooksListCacheGenKey = "v1:books:list_cache_gen"
+
+// Sentinel errors for ListBooks singleflight and callers (e.g. HTTP handlers).
+var (
+	ErrListBooksDB         = errors.New("service: list books database")
+	ErrListBooksMarshal    = errors.New("service: list books marshal")
+	ErrListBooksRedis      = errors.New("service: list books redis set")
+	ErrListBooksUnmarshal  = errors.New("service: list books cache unmarshal")
+)
+
+// BooksListDataCacheKey is the Redis key for a cached books list page (tests and docs).
+func BooksListDataCacheKey(gen int64, offset, limit int) string {
+	return fmt.Sprintf("books_g%d_offset_%d_limit_%d", gen, offset, limit)
+}
+
+// BookService coordinates book reads/writes, list caching, and cache generation bumps.
+type BookService struct {
+	store  repository.BookPersistence
+	redis  cache.Cache
+	listSF singleflight.Group
+}
+
+// NewBookService constructs a BookService.
+func NewBookService(store repository.BookPersistence, redis cache.Cache) *BookService {
+	return &BookService{store: store, redis: redis}
+}
+
+func (s *BookService) cacheGeneration(ctx context.Context) int64 {
+	if s == nil || s.redis == nil {
+		return 0
+	}
+	n, err := s.redis.Get(ctx, BooksListCacheGenKey).Int64()
+	if err != nil {
+		return 0
+	}
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func (s *BookService) bumpListCacheGeneration(ctx context.Context) {
+	if s == nil || s.redis == nil {
+		return
+	}
+	_, _ = s.redis.Incr(ctx, BooksListCacheGenKey).Result()
+}
+
+// ListBooks returns books for offset/limit using Redis list cache and singleflight on miss.
+func (s *BookService) ListBooks(ctx context.Context, offset, limit int) ([]models.Book, error) {
+	if s.redis == nil {
+		return s.store.List(offset, limit)
+	}
+
+	gen := s.cacheGeneration(ctx)
+	cacheKey := BooksListDataCacheKey(gen, offset, limit)
+
+	cachedBooks, err := s.redis.Get(ctx, cacheKey).Result()
+	if err == nil {
+		var books []models.Book
+		if err := json.Unmarshal([]byte(cachedBooks), &books); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrListBooksUnmarshal, err)
+		}
+		return books, nil
+	}
+
+	out, err, _ := s.listSF.Do(cacheKey, func() (interface{}, error) {
+		loaded, err := s.store.List(offset, limit)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrListBooksDB, err)
+		}
+		serializedBooks, err := json.Marshal(loaded)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrListBooksMarshal, err)
+		}
+		if err := s.redis.Set(ctx, cacheKey, serializedBooks, time.Minute).Err(); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrListBooksRedis, err)
+		}
+		return loaded, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out.([]models.Book), nil
+}
+
+// CreateBook persists a new book and bumps the list cache generation.
+func (s *BookService) CreateBook(ctx context.Context, title, author string) (*models.Book, error) {
+	book := &models.Book{Title: title, Author: author}
+	if err := s.store.Create(book); err != nil {
+		return nil, err
+	}
+	s.bumpListCacheGeneration(ctx)
+	return book, nil
+}
+
+// GetBook returns a book by id or gorm.ErrRecordNotFound-compatible error from the store.
+func (s *BookService) GetBook(_ context.Context, id uint) (*models.Book, error) {
+	return s.store.FirstByID(id)
+}
+
+// UpdateBook updates fields and bumps list cache generation.
+func (s *BookService) UpdateBook(ctx context.Context, id uint, title, author string) (*models.Book, error) {
+	book, err := s.store.UpdateFields(id, title, author)
+	if err != nil {
+		return nil, err
+	}
+	s.bumpListCacheGeneration(ctx)
+	return book, nil
+}
+
+// DeleteBook removes a book by id and bumps list cache generation.
+func (s *BookService) DeleteBook(ctx context.Context, id uint) error {
+	if err := s.store.DeleteByID(id); err != nil {
+		return err
+	}
+	s.bumpListCacheGeneration(ctx)
+	return nil
+}

--- a/pkg/service/book_service_test.go
+++ b/pkg/service/book_service_test.go
@@ -1,0 +1,250 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/models"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeBookStore struct {
+	listFn    func(offset, limit int) ([]models.Book, error)
+	createFn  func(book *models.Book) error
+	firstFn   func(id uint) (*models.Book, error)
+	updateFn  func(id uint, title, author string) (*models.Book, error)
+	deleteFn  func(id uint) error
+}
+
+func (f *fakeBookStore) List(offset, limit int) ([]models.Book, error) {
+	if f.listFn != nil {
+		return f.listFn(offset, limit)
+	}
+	return nil, nil
+}
+
+func (f *fakeBookStore) Create(book *models.Book) error {
+	if f.createFn != nil {
+		return f.createFn(book)
+	}
+	return nil
+}
+
+func (f *fakeBookStore) FirstByID(id uint) (*models.Book, error) {
+	if f.firstFn != nil {
+		return f.firstFn(id)
+	}
+	return nil, nil
+}
+
+func (f *fakeBookStore) UpdateFields(id uint, title, author string) (*models.Book, error) {
+	if f.updateFn != nil {
+		return f.updateFn(id, title, author)
+	}
+	return nil, nil
+}
+
+func (f *fakeBookStore) DeleteByID(id uint) error {
+	if f.deleteFn != nil {
+		return f.deleteFn(id)
+	}
+	return nil
+}
+
+func TestBooksListDataCacheKey(t *testing.T) {
+	assert.Equal(t, "books_g2_offset_5_limit_10", BooksListDataCacheKey(2, 5, 10))
+}
+
+func TestListBooksNilRedisUsesStore(t *testing.T) {
+	want := []models.Book{{ID: 1, Title: "a", Author: "b"}}
+	store := &fakeBookStore{
+		listFn: func(offset, limit int) ([]models.Book, error) {
+			assert.Equal(t, 3, offset)
+			assert.Equal(t, 7, limit)
+			return want, nil
+		},
+	}
+	svc := NewBookService(store, nil)
+	got, err := svc.ListBooks(context.Background(), 3, 7)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestListBooksCacheHit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+
+	want := []models.Book{{ID: 9, Title: "cached", Author: "x"}}
+	payload, err := json.Marshal(want)
+	assert.NoError(t, err)
+	dataKey := BooksListDataCacheKey(0, 0, 10)
+
+	gomock.InOrder(
+		mockRedis.EXPECT().Get(gomock.Any(), BooksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockRedis.EXPECT().Get(gomock.Any(), dataKey).Return(redis.NewStringResult(string(payload), nil)),
+	)
+
+	store := &fakeBookStore{
+		listFn: func(offset, limit int) ([]models.Book, error) {
+			t.Fatal("store.List should not run on cache hit")
+			return nil, nil
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	got, err := svc.ListBooks(context.Background(), 0, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestListBooksCacheUnmarshalError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	dataKey := BooksListDataCacheKey(0, 1, 5)
+
+	gomock.InOrder(
+		mockRedis.EXPECT().Get(gomock.Any(), BooksListCacheGenKey).Return(redis.NewStringResult("0", nil)),
+		mockRedis.EXPECT().Get(gomock.Any(), dataKey).Return(redis.NewStringResult("not-json", nil)),
+	)
+
+	svc := NewBookService(&fakeBookStore{}, mockRedis)
+	_, err := svc.ListBooks(context.Background(), 1, 5)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrListBooksUnmarshal)
+}
+
+func TestListBooksStoreError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	dataKey := BooksListDataCacheKey(0, 0, 10)
+	dbErr := errors.New("db down")
+
+	gomock.InOrder(
+		mockRedis.EXPECT().Get(gomock.Any(), BooksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockRedis.EXPECT().Get(gomock.Any(), dataKey).Return(redis.NewStringResult("", redis.Nil)),
+	)
+
+	store := &fakeBookStore{
+		listFn: func(offset, limit int) ([]models.Book, error) {
+			return nil, dbErr
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	_, err := svc.ListBooks(context.Background(), 0, 10)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrListBooksDB)
+}
+
+func TestListBooksRedisSetError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	dataKey := BooksListDataCacheKey(0, 0, 10)
+	want := []models.Book{{Title: "t", Author: "a"}}
+
+	gomock.InOrder(
+		mockRedis.EXPECT().Get(gomock.Any(), BooksListCacheGenKey).Return(redis.NewStringResult("", redis.Nil)),
+		mockRedis.EXPECT().Get(gomock.Any(), dataKey).Return(redis.NewStringResult("", redis.Nil)),
+	)
+	mockRedis.EXPECT().Set(gomock.Any(), dataKey, gomock.Any(), time.Minute).Return(redis.NewStatusResult("", errors.New("set failed")))
+
+	store := &fakeBookStore{
+		listFn: func(offset, limit int) ([]models.Book, error) {
+			return want, nil
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	_, err := svc.ListBooks(context.Background(), 0, 10)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrListBooksRedis)
+}
+
+func TestCreateBookBumpsGenerationWhenRedis(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	mockRedis.EXPECT().Incr(gomock.Any(), BooksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+
+	store := &fakeBookStore{
+		createFn: func(book *models.Book) error {
+			book.ID = 42
+			return nil
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	book, err := svc.CreateBook(context.Background(), "t", "a")
+	assert.NoError(t, err)
+	assert.NotNil(t, book)
+	assert.Equal(t, uint(42), book.ID)
+}
+
+func TestCreateBookNoIncrWhenNilRedis(t *testing.T) {
+	store := &fakeBookStore{
+		createFn: func(book *models.Book) error {
+			return nil
+		},
+	}
+	svc := NewBookService(store, nil)
+	_, err := svc.CreateBook(context.Background(), "t", "a")
+	assert.NoError(t, err)
+}
+
+func TestGetBookDelegates(t *testing.T) {
+	want := &models.Book{ID: 3, Title: "x", Author: "y"}
+	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			assert.Equal(t, uint(3), id)
+			return want, nil
+		},
+	}
+	svc := NewBookService(store, nil)
+	got, err := svc.GetBook(context.Background(), 3)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestUpdateBookBumpsGeneration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	mockRedis.EXPECT().Incr(gomock.Any(), BooksListCacheGenKey).Return(redis.NewIntResult(2, nil)).Times(1)
+
+	updated := &models.Book{ID: 1, Title: "n", Author: "m"}
+	store := &fakeBookStore{
+		updateFn: func(id uint, title, author string) (*models.Book, error) {
+			assert.Equal(t, uint(1), id)
+			assert.Equal(t, "n", title)
+			assert.Equal(t, "m", author)
+			return updated, nil
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	got, err := svc.UpdateBook(context.Background(), 1, "n", "m")
+	assert.NoError(t, err)
+	assert.Equal(t, updated, got)
+}
+
+func TestDeleteBookBumpsGeneration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	mockRedis.EXPECT().Incr(gomock.Any(), BooksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
+
+	store := &fakeBookStore{
+		deleteFn: func(id uint) error {
+			assert.Equal(t, uint(9), id)
+			return nil
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	assert.NoError(t, svc.DeleteBook(context.Background(), 9))
+}

--- a/pkg/service/user_service.go
+++ b/pkg/service/user_service.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/models"
+	"golang-rest-api-template/pkg/repository"
+
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+// Sentinel errors for login / registration.
+var (
+	ErrInvalidLogin      = errors.New("service: invalid username or password")
+	ErrLoginDB           = errors.New("service: login database error")
+	ErrTokenGenerate     = errors.New("service: token generation failed")
+	ErrRegisterConflict  = errors.New("service: username already taken")
+	ErrRegisterHash      = errors.New("service: password hash failed")
+	ErrRegisterSave      = errors.New("service: could not save user")
+)
+
+// UserService handles authentication use-cases without Gin.
+type UserService struct {
+	users repository.UserPersistence
+}
+
+// NewUserService constructs a UserService.
+func NewUserService(users repository.UserPersistence) *UserService {
+	return &UserService{users: users}
+}
+
+// Login validates credentials and returns a JWT token string.
+func (s *UserService) Login(_ context.Context, username, password string) (token string, err error) {
+	dbUser, err := s.users.FindByUsername(username)
+	if err != nil {
+		if repository.IsUserNotFound(err) {
+			return "", ErrInvalidLogin
+		}
+		return "", fmtError(ErrLoginDB, err)
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(password)); err != nil {
+		return "", ErrInvalidLogin
+	}
+	tok, err := auth.GenerateToken(dbUser.Username)
+	if err != nil {
+		return "", fmtError(ErrTokenGenerate, err)
+	}
+	return tok, nil
+}
+
+// Register creates a new user account.
+func (s *UserService) Register(_ context.Context, username, password string) error {
+	hashedPassword, err := auth.HashPassword(password)
+	if err != nil {
+		return fmtError(ErrRegisterHash, err)
+	}
+	newUser := &models.User{Username: username, Password: hashedPassword}
+	if err := s.users.Create(newUser); err != nil {
+		if registerUsernameConflict(err) {
+			return ErrRegisterConflict
+		}
+		return fmtError(ErrRegisterSave, err)
+	}
+	return nil
+}
+
+func fmtError(sentinel error, cause error) error {
+	return fmt.Errorf("%w: %v", sentinel, cause)
+}
+
+func registerUsernameConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	if strings.Contains(s, "unique constraint failed") {
+		return true
+	}
+	if strings.Contains(s, "duplicate key") && strings.Contains(s, "unique") {
+		return true
+	}
+	return false
+}

--- a/pkg/service/user_service_test.go
+++ b/pkg/service/user_service_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/models"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+)
+
+type fakeUserStore struct {
+	findFn   func(username string) (*models.User, error)
+	createFn func(user *models.User) error
+}
+
+func (f *fakeUserStore) FindByUsername(username string) (*models.User, error) {
+	if f.findFn != nil {
+		return f.findFn(username)
+	}
+	return nil, nil
+}
+
+func (f *fakeUserStore) Create(user *models.User) error {
+	if f.createFn != nil {
+		return f.createFn(user)
+	}
+	return nil
+}
+
+func TestUserServiceLoginUserNotFound(t *testing.T) {
+	store := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	svc := NewUserService(store)
+	_, err := svc.Login(context.Background(), "nobody", "pw")
+	assert.ErrorIs(t, err, ErrInvalidLogin)
+}
+
+func TestUserServiceLoginWrongPassword(t *testing.T) {
+	hash, err := bcrypt.GenerateFromPassword([]byte("right"), bcrypt.MinCost)
+	assert.NoError(t, err)
+	store := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return &models.User{Username: "u", Password: string(hash)}, nil
+		},
+	}
+	svc := NewUserService(store)
+	_, err = svc.Login(context.Background(), "u", "wrong")
+	assert.ErrorIs(t, err, ErrInvalidLogin)
+}
+
+func TestUserServiceLoginDBError(t *testing.T) {
+	dbErr := errors.New("connection refused")
+	store := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return nil, dbErr
+		},
+	}
+	svc := NewUserService(store)
+	_, err := svc.Login(context.Background(), "u", "p")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrLoginDB)
+}
+
+func TestUserServiceLoginSuccess(t *testing.T) {
+	prev := auth.JWTSigningKey()
+	t.Cleanup(func() { _ = auth.SetJWTSigningKey(prev) })
+	assert.NoError(t, auth.SetJWTSigningKey(bytes.Repeat([]byte("s"), auth.MinJWTSecretKeyBytes)))
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("secret"), bcrypt.MinCost)
+	assert.NoError(t, err)
+	store := &fakeUserStore{
+		findFn: func(username string) (*models.User, error) {
+			return &models.User{Username: "alice", Password: string(hash)}, nil
+		},
+	}
+	svc := NewUserService(store)
+	tok, err := svc.Login(context.Background(), "alice", "secret")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, tok)
+}
+
+func TestUserServiceRegisterConflictDuplicatedKey(t *testing.T) {
+	store := &fakeUserStore{
+		createFn: func(user *models.User) error {
+			return gorm.ErrDuplicatedKey
+		},
+	}
+	svc := NewUserService(store)
+	err := svc.Register(context.Background(), "dup", "password123")
+	assert.ErrorIs(t, err, ErrRegisterConflict)
+}
+
+func TestUserServiceRegisterConflictSQLiteMessage(t *testing.T) {
+	store := &fakeUserStore{
+		createFn: func(user *models.User) error {
+			return errors.New("UNIQUE constraint failed: users.username")
+		},
+	}
+	svc := NewUserService(store)
+	err := svc.Register(context.Background(), "dup", "password123")
+	assert.ErrorIs(t, err, ErrRegisterConflict)
+}
+
+func TestUserServiceRegisterSaveError(t *testing.T) {
+	saveErr := errors.New("disk full")
+	store := &fakeUserStore{
+		createFn: func(user *models.User) error {
+			return saveErr
+		},
+	}
+	svc := NewUserService(store)
+	err := svc.Register(context.Background(), "u", "password123")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrRegisterSave)
+}


### PR DESCRIPTION
## Summary

Introduces a **handler → service → repository** layout for books and users ([issue #114](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/114)):

- **`pkg/repository`**: `BookPersistence` / `UserPersistence` interfaces and GORM implementations (`GormBookStore`, `GormUserStore`) with `IsBookNotFound` / `IsUserNotFound` helpers.
- **`pkg/service`**: `BookService` (list cache, generation key, singleflight, CRUD + cache bump) and `UserService` (login, register, sentinel errors). Exported `BooksListCacheGenKey` and `BooksListDataCacheKey` for tests and observability.
- **`pkg/api`**: Thin Gin handlers that bind/validate HTTP and map service/repository errors to status codes. Router wiring unchanged (`NewBookRepository` / `NewUserRepository`).

`ListBooks` skips Redis when the cache client is nil (safe for tests). Repository `UpdateFields` returns the model with updated title/author for the response body.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

## How to test

```bash
go test ./... -race
```

<!-- If you changed HTTP behavior, Docker, or integration tests: -->

```bash
# optional: local stack
# make up

# optional: Python E2E (see README; requires BASE_URL and API_KEY)
# pytest -v tests/e2e.py
```

## Checklist

- [x] `go test ./... -race` passes locally
- [ ] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [ ] If you added or renamed **environment variables**: README and/or `.env` examples are updated
- [ ] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #114
