### PR TITLE
feat: book ownership and JWT user_id (fix #117)

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -257,6 +257,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "book not found",
                         "schema": {
@@ -303,6 +309,12 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }
@@ -448,6 +460,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "id": {
+                    "type": "integer"
+                },
+                "owner_id": {
                     "type": "integer"
                 },
                 "title": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -251,6 +251,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "book not found",
                         "schema": {
@@ -297,6 +303,12 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }
@@ -442,6 +454,9 @@
                     "type": "string"
                 },
                 "id": {
+                    "type": "integer"
+                },
+                "owner_id": {
                     "type": "integer"
                 },
                 "title": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -8,6 +8,8 @@ definitions:
         type: string
       id:
         type: integer
+      owner_id:
+        type: integer
       title:
         type: string
       updated_at:
@@ -168,6 +170,10 @@ paths:
           description: Unauthorized
           schema:
             type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
         "404":
           description: book not found
           schema:
@@ -235,6 +241,10 @@ paths:
             type: string
         "401":
           description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
           schema:
             type: string
         "404":

--- a/pkg/api/book_routes_auth_test.go
+++ b/pkg/api/book_routes_auth_test.go
@@ -36,7 +36,7 @@ func testBookWriteMiddlewareStack(t *testing.T) *gin.Engine {
 func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
 	const apiKey = testAPISecretKey
 
-	token, err := auth.GenerateToken("book-writer")
+	token, err := auth.GenerateToken("book-writer", 1)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -141,7 +141,7 @@ func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
 func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
 	const apiKey = testAPISecretKey
 
-	token, err := auth.GenerateToken("u1")
+	token, err := auth.GenerateToken("u1", 1)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -175,7 +175,7 @@ func TestBookWriteRoutesRejectTamperedJWT(t *testing.T) {
 func TestBookWriteRoutesConcurrentAuthorizedRequests(t *testing.T) {
 	const apiKey = testAPISecretKey
 
-	token, err := auth.GenerateToken("concurrent-user")
+	token, err := auth.GenerateToken("concurrent-user", 1)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/middleware"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 	"golang-rest-api-template/pkg/service"
@@ -80,6 +81,19 @@ func parseOffsetLimit(c *gin.Context) (offset, limit int, ok bool) {
 	return o, l, true
 }
 
+// contextUserID returns the authenticated users.id set by middleware.JWTAuth.
+func contextUserID(c *gin.Context) (uint, bool) {
+	if c == nil {
+		return 0, false
+	}
+	v, ok := c.Get(middleware.ContextUserID)
+	if !ok {
+		return 0, false
+	}
+	id, ok := v.(uint)
+	return id, ok && id > 0
+}
+
 // @BasePath /api/v1
 
 // Healthcheck godoc
@@ -146,12 +160,17 @@ func (h *bookHandler) FindBooks(c *gin.Context) {
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books [post]
 func (h *bookHandler) CreateBook(c *gin.Context) {
+	ownerID, ok := contextUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
 	var input models.CreateBook
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	book, err := h.svc.CreateBook(c.Request.Context(), input.Title, input.Author)
+	book, err := h.svc.CreateBook(c.Request.Context(), ownerID, input.Title, input.Author)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book"})
 		return
@@ -199,10 +218,16 @@ func (h *bookHandler) FindBook(c *gin.Context) {
 // @Success 200 {object} models.Book "Successfully updated book"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
 // @Failure 404 {string} string "book not found"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books/{id} [put]
 func (h *bookHandler) UpdateBook(c *gin.Context) {
+	actorID, ok := contextUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
 	var input models.UpdateBook
 	id, ok := parseIDParam(c)
 	if !ok {
@@ -212,10 +237,14 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	book, err := h.svc.UpdateBook(c.Request.Context(), id, input.Title, input.Author)
+	book, err := h.svc.UpdateBook(c.Request.Context(), actorID, id, input.Title, input.Author)
 	if err != nil {
 		if repository.IsBookNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			return
+		}
+		if errors.Is(err, service.ErrBookForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update book"})
@@ -234,17 +263,27 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 // @Param id path string true "Book ID"
 // @Success 204 "Successfully deleted book"
 // @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
 // @Failure 404 {string} string "book not found"
 // @Failure 500 {string} string "Internal Server Error"
 // @Router /books/{id} [delete]
 func (h *bookHandler) DeleteBook(c *gin.Context) {
+	actorID, ok := contextUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
 	id, ok := parseIDParam(c)
 	if !ok {
 		return
 	}
-	if err := h.svc.DeleteBook(c.Request.Context(), id); err != nil {
+	if err := h.svc.DeleteBook(c.Request.Context(), actorID, id); err != nil {
 		if repository.IsBookNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			return
+		}
+		if errors.Is(err, service.ErrBookForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete book"})

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/middleware"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 	"golang-rest-api-template/pkg/service"
@@ -27,6 +28,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"gorm.io/driver/sqlite"
 )
+
+// withBookActor injects the authenticated user id as JWTAuth would (for handler tests).
+func withBookActor(userID uint) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(middleware.ContextUserID, userID)
+		c.Set("username", "test-user")
+		c.Next()
+	}
+}
 
 func TestNewBookHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -160,7 +170,7 @@ func TestFindBooksLimitCappedAtMax(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < 120; i++ {
-		if err := db.Create(&models.Book{Title: "b" + strconv.Itoa(i), Author: "a"}).Error; err != nil {
+		if err := db.Create(&models.Book{OwnerID: 1, Title: "b" + strconv.Itoa(i), Author: "a"}).Error; err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -202,7 +212,7 @@ func TestCreateBookDatabaseError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", h.CreateBook)
+	r.POST("/books", withBookActor(1), h.CreateBook)
 
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
 	requestBody, err := json.Marshal(inputBook)
@@ -236,7 +246,7 @@ func TestCreateBookBindError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", h.CreateBook)
+	r.POST("/books", withBookActor(1), h.CreateBook)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "/books", bytes.NewBufferString("invalid json"))
@@ -245,6 +255,24 @@ func TestCreateBookBindError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "error")
+}
+
+func TestCreateBookRequiresAuthContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	h := NewBookHandler(repository.NewMockBookPersistence(ctrl), cache.NewMockCache(ctrl))
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.POST("/books", h.CreateBook)
+	body, err := json.Marshal(models.CreateBook{Title: "x", Author: "y"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/books", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
 
 func TestCreateBookCacheIncrError(t *testing.T) {
@@ -258,7 +286,7 @@ func TestCreateBookCacheIncrError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", h.CreateBook)
+	r.POST("/books", withBookActor(1), h.CreateBook)
 
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
 	requestBody, _ := json.Marshal(inputBook)
@@ -285,7 +313,7 @@ func TestUpdateBookInvalidID(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.PUT("/book/:id", h.UpdateBook)
+	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
 	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
 	requestBody, _ := json.Marshal(updateInput)
@@ -308,12 +336,12 @@ func TestUpdateBookNotFound(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.PUT("/book/:id", h.UpdateBook)
+	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
 	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
 	requestBody, _ := json.Marshal(updateInput)
 
-	mockStore.EXPECT().UpdateFields(uint(1), "New Title", "New Author").Return(nil, gorm.ErrRecordNotFound)
+	mockStore.EXPECT().FirstByID(uint(1)).Return(nil, gorm.ErrRecordNotFound)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("PUT", "/book/1", bytes.NewBuffer(requestBody))
@@ -322,6 +350,33 @@ func TestUpdateBookNotFound(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 	assert.Contains(t, w.Body.String(), "book not found")
+}
+
+func TestUpdateBookForbiddenWrongOwner(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Book{OwnerID: 1, Title: "mine", Author: "a"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	h := NewBookHandler(repository.NewGormBookStore(db), nil)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.PUT("/book/:id", withBookActor(2), h.UpdateBook)
+	body, err := json.Marshal(models.UpdateBook{Title: "n", Author: "n"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/book/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Contains(t, w.Body.String(), "forbidden")
 }
 
 func TestUpdateBookBindError(t *testing.T) {
@@ -333,7 +388,7 @@ func TestUpdateBookBindError(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.PUT("/book/:id", h.UpdateBook)
+	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("PUT", "/book/1", bytes.NewBufferString("invalid json"))
@@ -394,7 +449,7 @@ func TestUpdateBookDatabaseErrorOnUpdates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	existingBook := models.Book{Title: "Old Title", Author: "Old Author"}
+	existingBook := models.Book{OwnerID: 1, Title: "Old Title", Author: "Old Author"}
 	if err := db.Create(&existingBook).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -413,7 +468,7 @@ func TestUpdateBookDatabaseErrorOnUpdates(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.PUT("/book/:id", h.UpdateBook)
+	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
 	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
 	requestBody, err := json.Marshal(updateInput)
@@ -439,7 +494,7 @@ func TestUpdateBookBumpsListCacheGen(t *testing.T) {
 	if err := db.AutoMigrate(&models.Book{}); err != nil {
 		t.Fatal(err)
 	}
-	b := models.Book{Title: "t", Author: "a"}
+	b := models.Book{OwnerID: 1, Title: "t", Author: "a"}
 	if err := db.Create(&b).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -452,7 +507,7 @@ func TestUpdateBookBumpsListCacheGen(t *testing.T) {
 	h := NewBookHandler(repository.NewGormBookStore(db), mockCache)
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.PUT("/book/:id", h.UpdateBook)
+	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
 	body, err := json.Marshal(models.UpdateBook{Title: "n", Author: "n"})
 	if err != nil {
@@ -474,7 +529,7 @@ func TestDeleteBookBumpsListCacheGen(t *testing.T) {
 	if err := db.AutoMigrate(&models.Book{}); err != nil {
 		t.Fatal(err)
 	}
-	b := models.Book{Title: "del", Author: "me"}
+	b := models.Book{OwnerID: 1, Title: "del", Author: "me"}
 	if err := db.Create(&b).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +542,7 @@ func TestDeleteBookBumpsListCacheGen(t *testing.T) {
 	h := NewBookHandler(repository.NewGormBookStore(db), mockCache)
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.DELETE("/book/:id", h.DeleteBook)
+	r.DELETE("/book/:id", withBookActor(1), h.DeleteBook)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodDelete, "/book/1", nil)
@@ -504,7 +559,7 @@ func TestDeleteBookInvalidID(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.DELETE("/book/:id", h.DeleteBook)
+	r.DELETE("/book/:id", withBookActor(1), h.DeleteBook)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodDelete, "/book/xyz", nil)
@@ -523,9 +578,9 @@ func TestDeleteBookNotFound(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.DELETE("/book/:id", h.DeleteBook)
+	r.DELETE("/book/:id", withBookActor(1), h.DeleteBook)
 
-	mockStore.EXPECT().DeleteByID(uint(1)).Return(gorm.ErrRecordNotFound)
+	mockStore.EXPECT().FirstByID(uint(1)).Return(nil, gorm.ErrRecordNotFound)
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest(http.MethodDelete, "/book/1", nil)
@@ -544,7 +599,7 @@ func TestFindBooks(t *testing.T) {
 	if err := db.AutoMigrate(&models.Book{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Create(&models.Book{Title: "Book One", Author: "Author One"}).Error; err != nil {
+	if err := db.Create(&models.Book{OwnerID: 1, Title: "Book One", Author: "Author One"}).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -584,7 +639,7 @@ func TestCreateBook(t *testing.T) {
 	// Set up Gin
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.POST("/books", h.CreateBook)
+	r.POST("/books", withBookActor(1), h.CreateBook)
 
 	// Example data for the test
 	inputBook := models.CreateBook{Title: "New Book", Author: "New Author"}
@@ -701,8 +756,9 @@ func TestDeleteBook(t *testing.T) {
 	// Set up Gin for testing
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.DELETE("/book/:id", h.DeleteBook)
+	r.DELETE("/book/:id", withBookActor(1), h.DeleteBook)
 
+	mockStore.EXPECT().FirstByID(uint(1)).Return(&models.Book{ID: 1, OwnerID: 1, Title: "t", Author: "a"}, nil).Times(1)
 	mockStore.EXPECT().DeleteByID(uint(1)).Return(nil).Times(1)
 
 	w := httptest.NewRecorder()
@@ -722,9 +778,10 @@ func TestDeleteBookDatabaseErrorOnDelete(t *testing.T) {
 
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
-	r.DELETE("/book/:id", h.DeleteBook)
+	r.DELETE("/book/:id", withBookActor(1), h.DeleteBook)
 
 	delErr := errors.New("delete failed")
+	mockStore.EXPECT().FirstByID(uint(1)).Return(&models.Book{ID: 1, OwnerID: 1}, nil).Times(1)
 	mockStore.EXPECT().DeleteByID(uint(1)).Return(delErr).Times(1)
 
 	w := httptest.NewRecorder()
@@ -744,7 +801,7 @@ func TestFindBooksSingleflightCoalescesDB(t *testing.T) {
 	if err := db.AutoMigrate(&models.Book{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Create(&models.Book{Title: "Coalesced", Author: "Author"}).Error; err != nil {
+	if err := db.Create(&models.Book{OwnerID: 1, Title: "Coalesced", Author: "Author"}).Error; err != nil {
 		t.Fatal(err)
 	}
 
@@ -839,7 +896,7 @@ func TestFindBooksLeadingZerosShareListCache(t *testing.T) {
 	if err := db.AutoMigrate(&models.Book{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Create(&models.Book{Title: "One", Author: "A"}).Error; err != nil {
+	if err := db.Create(&models.Book{OwnerID: 1, Title: "One", Author: "A"}).Error; err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -32,6 +32,8 @@ var (
 // Claims carries custom JWT fields plus registered (standard) JWT claims.
 type Claims struct {
 	Username string `json:"username"`
+	// UserID is the authenticated users.id used for authorization (must be non-zero).
+	UserID uint `json:"user_id"`
 	jwt.RegisteredClaims
 }
 
@@ -90,7 +92,12 @@ func HashPassword(password string) (string, error) {
 	return string(bytes), err
 }
 
-func GenerateToken(username string) (string, error) {
+// GenerateToken issues an HS256 JWT with username and user_id claims. userID must
+// be non-zero (database primary key of the authenticated user).
+func GenerateToken(username string, userID uint) (string, error) {
+	if userID == 0 {
+		return "", fmt.Errorf("auth.GenerateToken: user id must be non-zero")
+	}
 	signingMu.RLock()
 	key := jwtSigningKey
 	signingMu.RUnlock()
@@ -101,6 +108,7 @@ func GenerateToken(username string) (string, error) {
 	exp := time.Now().Add(5 * time.Minute)
 	claims := &Claims{
 		Username: username,
+		UserID:   userID,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -27,14 +27,15 @@ func TestHashPassword(t *testing.T) {
 
 func TestGenerateToken(t *testing.T) {
 	user := "chud"
-	token, err := GenerateToken(user)
+	token, err := GenerateToken(user, 1)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, token)
 }
 
 func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
 	const wantUser = "alice"
-	tokenStr, err := GenerateToken(wantUser)
+	const wantID uint = 42
+	tokenStr, err := GenerateToken(wantUser, wantID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -48,6 +49,7 @@ func TestGenerateTokenRoundTripUsernameClaim(t *testing.T) {
 		return
 	}
 	assert.Equal(t, wantUser, parsed.Username)
+	assert.Equal(t, wantID, parsed.UserID)
 }
 
 func TestGenerateRandomKey(t *testing.T) {
@@ -71,7 +73,7 @@ func TestSetJWTSigningKeyAcceptsMinimumLength(t *testing.T) {
 		return
 	}
 	assert.Equal(t, secret, JWTSigningKey())
-	_, err = GenerateToken("user-after-rotate")
+	_, err = GenerateToken("user-after-rotate", 1)
 	assert.NoError(t, err)
 	// Restore default for other tests in the package.
 	assert.NoError(t, SetJWTSigningKey(bytes.Repeat([]byte("k"), MinJWTSecretKeyBytes)))
@@ -83,9 +85,14 @@ func TestGenerateTokenErrorWhenSigningKeyUnset(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, SetJWTSigningKey(prev))
 	})
-	_, err := GenerateToken("any")
+	_, err := GenerateToken("any", 1)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, ErrJWTSigningKeyNotConfigured))
+}
+
+func TestGenerateTokenRejectsZeroUserID(t *testing.T) {
+	_, err := GenerateToken("u", 0)
+	assert.Error(t, err)
 }
 
 func TestJWTKeyFuncRejectsNonHS256Algorithms(t *testing.T) {
@@ -93,6 +100,7 @@ func TestJWTKeyFuncRejectsNonHS256Algorithms(t *testing.T) {
 	exp := time.Now().Add(time.Hour)
 	baseClaims := Claims{
 		Username: "attacker",
+		UserID:   1,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
@@ -127,6 +135,7 @@ func TestJWTKeyFuncAcceptsHS256(t *testing.T) {
 	key := []byte("jwt-keyfunc-hs256-accept-secret!")
 	claims := &Claims{
 		Username: "legit",
+		UserID:   9,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},

--- a/pkg/middleware/jwt_auth.go
+++ b/pkg/middleware/jwt_auth.go
@@ -9,6 +9,10 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// ContextUserID is the Gin context key for the authenticated user's numeric ID
+// (users.id), set by JWTAuth after successful verification.
+const ContextUserID = "user_id"
+
 // JWTAuth returns Gin middleware that requires a valid Bearer JWT signed
 // with HMAC-SHA256 using the application's JWT secret. Other algorithms are
 // rejected before signature verification.
@@ -52,7 +56,14 @@ func JWTAuth() gin.HandlerFunc {
 			return
 		}
 
+		if claims.UserID == 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
+			c.Abort()
+			return
+		}
+
 		c.Set("username", claims.Username)
+		c.Set(ContextUserID, claims.UserID)
 		c.Next()
 	}
 }

--- a/pkg/middleware/jwt_auth_test.go
+++ b/pkg/middleware/jwt_auth_test.go
@@ -53,7 +53,7 @@ func TestJWTAuthSigningKeyNotConfiguredReturns503(t *testing.T) {
 }
 
 func TestJWTAuthValidBearer(t *testing.T) {
-	token, err := auth.GenerateToken("middleware-user")
+	token, err := auth.GenerateToken("middleware-user", 1)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -67,9 +67,33 @@ func TestJWTAuthValidBearer(t *testing.T) {
 	}
 }
 
+func TestJWTAuthRejectsZeroUserIDClaim(t *testing.T) {
+	key := auth.JWTSigningKey()
+	claims := &auth.Claims{
+		Username: "legacy",
+		UserID:   0,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := testRouterJWTAuthOnly(t)
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+s)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%q", rec.Code, rec.Body.String())
+	}
+}
+
 func TestJWTAuthSetsUsernameContext(t *testing.T) {
 	const wantUser = "ctx-user"
-	token, err := auth.GenerateToken(wantUser)
+	token, err := auth.GenerateToken(wantUser, 99)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -98,8 +122,39 @@ func TestJWTAuthSetsUsernameContext(t *testing.T) {
 	}
 }
 
+func TestJWTAuthSetsUserIDContext(t *testing.T) {
+	const wantID uint = 77
+	token, err := auth.GenerateToken("uid-ctx-user", wantID)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	var got uint
+	r.GET("/p", JWTAuth(), func(c *gin.Context) {
+		v, ok := c.Get(ContextUserID)
+		if !ok {
+			t.Error("user id not in context")
+			c.Status(http.StatusInternalServerError)
+			return
+		}
+		got, _ = v.(uint)
+		c.Status(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/p", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: %d body=%q", rec.Code, rec.Body.String())
+	}
+	if got != wantID {
+		t.Fatalf("user id: got %d want %d", got, wantID)
+	}
+}
+
 func TestJWTAuthRejectsBadRequests(t *testing.T) {
-	validHS256, err := auth.GenerateToken("ok-user")
+	validHS256, err := auth.GenerateToken("ok-user", 1)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}
@@ -107,6 +162,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 	exp := time.Now().Add(time.Hour)
 	claims := &auth.Claims{
 		Username: "other",
+		UserID:   1,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(exp),
 		},
@@ -124,6 +180,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 
 	expiredClaims := &auth.Claims{
 		Username: "expired-user",
+		UserID:   1,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
 		},
@@ -137,6 +194,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 	wrongKey := bytes.Repeat([]byte("n"), auth.MinJWTSecretKeyBytes)
 	wrongSigClaims := &auth.Claims{
 		Username: "wrong-sig-user",
+		UserID:   1,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 		},
@@ -228,7 +286,7 @@ func TestJWTAuthRejectsBadRequests(t *testing.T) {
 }
 
 func TestJWTAuthConcurrentValidRequests(t *testing.T) {
-	token, err := auth.GenerateToken("concurrent-jwt-user")
+	token, err := auth.GenerateToken("concurrent-jwt-user", 1)
 	if err != nil {
 		t.Fatalf("GenerateToken: %v", err)
 	}

--- a/pkg/models/book.go
+++ b/pkg/models/book.go
@@ -4,6 +4,7 @@ import "time"
 
 type Book struct {
 	ID        uint      `json:"id" gorm:"primary_key"`
+	OwnerID   uint      `json:"owner_id" gorm:"index;not null"`
 	Title     string    `json:"title"`
 	Author    string    `json:"author"`
 	CreatedAt time.Time `json:"created_at" gorm:"autoCreateTime"`

--- a/pkg/repository/book_gorm_test.go
+++ b/pkg/repository/book_gorm_test.go
@@ -27,8 +27,8 @@ func TestGormBookStoreListCreateFirstByID(t *testing.T) {
 	db := testBookDB(t)
 	s := NewGormBookStore(db)
 
-	assert.NoError(t, s.Create(&models.Book{Title: "A", Author: "1"}))
-	assert.NoError(t, s.Create(&models.Book{Title: "B", Author: "2"}))
+	assert.NoError(t, s.Create(&models.Book{OwnerID: 1, Title: "A", Author: "1"}))
+	assert.NoError(t, s.Create(&models.Book{OwnerID: 1, Title: "B", Author: "2"}))
 
 	list, err := s.List(0, 10)
 	if !assert.NoError(t, err) {
@@ -58,7 +58,7 @@ func TestGormBookStoreListOffsetLimit(t *testing.T) {
 	db := testBookDB(t)
 	s := NewGormBookStore(db)
 	for i := 0; i < 5; i++ {
-		assert.NoError(t, s.Create(&models.Book{Title: string(rune('A' + i)), Author: "x"}))
+		assert.NoError(t, s.Create(&models.Book{OwnerID: 1, Title: string(rune('A' + i)), Author: "x"}))
 	}
 
 	page, err := s.List(1, 2)
@@ -71,7 +71,7 @@ func TestGormBookStoreListOffsetLimit(t *testing.T) {
 func TestGormBookStoreUpdateFields(t *testing.T) {
 	db := testBookDB(t)
 	s := NewGormBookStore(db)
-	b := &models.Book{Title: "old", Author: "old"}
+	b := &models.Book{OwnerID: 1, Title: "old", Author: "old"}
 	assert.NoError(t, s.Create(b))
 
 	out, err := s.UpdateFields(b.ID, "newt", "newa")
@@ -100,7 +100,7 @@ func TestGormBookStoreUpdateFieldsNotFound(t *testing.T) {
 func TestGormBookStoreDeleteByID(t *testing.T) {
 	db := testBookDB(t)
 	s := NewGormBookStore(db)
-	b := &models.Book{Title: "gone", Author: "soon"}
+	b := &models.Book{OwnerID: 1, Title: "gone", Author: "soon"}
 	assert.NoError(t, s.Create(b))
 
 	assert.NoError(t, s.DeleteByID(b.ID))
@@ -120,7 +120,7 @@ func TestGormBookStoreDeleteByIDNotFound(t *testing.T) {
 func TestGormBookStoreListConcurrent(t *testing.T) {
 	db := testBookDB(t)
 	s := NewGormBookStore(db)
-	assert.NoError(t, s.Create(&models.Book{Title: "c", Author: "c"}))
+	assert.NoError(t, s.Create(&models.Book{OwnerID: 1, Title: "c", Author: "c"}))
 
 	var wg sync.WaitGroup
 	const n = 32

--- a/pkg/service/book_service.go
+++ b/pkg/service/book_service.go
@@ -19,10 +19,11 @@ const BooksListCacheGenKey = "v1:books:list_cache_gen"
 
 // Sentinel errors for ListBooks singleflight and callers (e.g. HTTP handlers).
 var (
-	ErrListBooksDB         = errors.New("service: list books database")
-	ErrListBooksMarshal    = errors.New("service: list books marshal")
-	ErrListBooksRedis      = errors.New("service: list books redis set")
-	ErrListBooksUnmarshal  = errors.New("service: list books cache unmarshal")
+	ErrListBooksDB        = errors.New("service: list books database")
+	ErrListBooksMarshal   = errors.New("service: list books marshal")
+	ErrListBooksRedis     = errors.New("service: list books redis set")
+	ErrListBooksUnmarshal = errors.New("service: list books cache unmarshal")
+	ErrBookForbidden      = errors.New("service: book forbidden")
 )
 
 // BooksListDataCacheKey is the Redis key for a cached books list page (tests and docs).
@@ -101,9 +102,9 @@ func (s *BookService) ListBooks(ctx context.Context, offset, limit int) ([]model
 	return out.([]models.Book), nil
 }
 
-// CreateBook persists a new book and bumps the list cache generation.
-func (s *BookService) CreateBook(ctx context.Context, title, author string) (*models.Book, error) {
-	book := &models.Book{Title: title, Author: author}
+// CreateBook persists a new book owned by ownerID and bumps the list cache generation.
+func (s *BookService) CreateBook(ctx context.Context, ownerID uint, title, author string) (*models.Book, error) {
+	book := &models.Book{OwnerID: ownerID, Title: title, Author: author}
 	if err := s.store.Create(book); err != nil {
 		return nil, err
 	}
@@ -116,8 +117,15 @@ func (s *BookService) GetBook(_ context.Context, id uint) (*models.Book, error) 
 	return s.store.FirstByID(id)
 }
 
-// UpdateBook updates fields and bumps list cache generation.
-func (s *BookService) UpdateBook(ctx context.Context, id uint, title, author string) (*models.Book, error) {
+// UpdateBook updates fields when actorID owns the book, then bumps list cache generation.
+func (s *BookService) UpdateBook(ctx context.Context, actorID, id uint, title, author string) (*models.Book, error) {
+	b, err := s.store.FirstByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if b.OwnerID != actorID {
+		return nil, ErrBookForbidden
+	}
 	book, err := s.store.UpdateFields(id, title, author)
 	if err != nil {
 		return nil, err
@@ -126,8 +134,15 @@ func (s *BookService) UpdateBook(ctx context.Context, id uint, title, author str
 	return book, nil
 }
 
-// DeleteBook removes a book by id and bumps list cache generation.
-func (s *BookService) DeleteBook(ctx context.Context, id uint) error {
+// DeleteBook removes a book when actorID owns it, then bumps list cache generation.
+func (s *BookService) DeleteBook(ctx context.Context, actorID, id uint) error {
+	b, err := s.store.FirstByID(id)
+	if err != nil {
+		return err
+	}
+	if b.OwnerID != actorID {
+		return ErrBookForbidden
+	}
 	if err := s.store.DeleteByID(id); err != nil {
 		return err
 	}

--- a/pkg/service/book_service_test.go
+++ b/pkg/service/book_service_test.go
@@ -16,11 +16,11 @@ import (
 )
 
 type fakeBookStore struct {
-	listFn    func(offset, limit int) ([]models.Book, error)
-	createFn  func(book *models.Book) error
-	firstFn   func(id uint) (*models.Book, error)
-	updateFn  func(id uint, title, author string) (*models.Book, error)
-	deleteFn  func(id uint) error
+	listFn   func(offset, limit int) ([]models.Book, error)
+	createFn func(book *models.Book) error
+	firstFn  func(id uint) (*models.Book, error)
+	updateFn func(id uint, title, author string) (*models.Book, error)
+	deleteFn func(id uint) error
 }
 
 func (f *fakeBookStore) List(offset, limit int) ([]models.Book, error) {
@@ -181,10 +181,11 @@ func TestCreateBookBumpsGenerationWhenRedis(t *testing.T) {
 		},
 	}
 	svc := NewBookService(store, mockRedis)
-	book, err := svc.CreateBook(context.Background(), "t", "a")
+	book, err := svc.CreateBook(context.Background(), 1, "t", "a")
 	assert.NoError(t, err)
 	assert.NotNil(t, book)
 	assert.Equal(t, uint(42), book.ID)
+	assert.Equal(t, uint(1), book.OwnerID)
 }
 
 func TestCreateBookNoIncrWhenNilRedis(t *testing.T) {
@@ -194,7 +195,7 @@ func TestCreateBookNoIncrWhenNilRedis(t *testing.T) {
 		},
 	}
 	svc := NewBookService(store, nil)
-	_, err := svc.CreateBook(context.Background(), "t", "a")
+	_, err := svc.CreateBook(context.Background(), 1, "t", "a")
 	assert.NoError(t, err)
 }
 
@@ -218,8 +219,11 @@ func TestUpdateBookBumpsGeneration(t *testing.T) {
 	mockRedis := cache.NewMockCache(ctrl)
 	mockRedis.EXPECT().Incr(gomock.Any(), BooksListCacheGenKey).Return(redis.NewIntResult(2, nil)).Times(1)
 
-	updated := &models.Book{ID: 1, Title: "n", Author: "m"}
+	updated := &models.Book{ID: 1, OwnerID: 5, Title: "n", Author: "m"}
 	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			return &models.Book{ID: 1, OwnerID: 5, Title: "o", Author: "o"}, nil
+		},
 		updateFn: func(id uint, title, author string) (*models.Book, error) {
 			assert.Equal(t, uint(1), id)
 			assert.Equal(t, "n", title)
@@ -228,7 +232,7 @@ func TestUpdateBookBumpsGeneration(t *testing.T) {
 		},
 	}
 	svc := NewBookService(store, mockRedis)
-	got, err := svc.UpdateBook(context.Background(), 1, "n", "m")
+	got, err := svc.UpdateBook(context.Background(), 5, 1, "n", "m")
 	assert.NoError(t, err)
 	assert.Equal(t, updated, got)
 }
@@ -240,11 +244,35 @@ func TestDeleteBookBumpsGeneration(t *testing.T) {
 	mockRedis.EXPECT().Incr(gomock.Any(), BooksListCacheGenKey).Return(redis.NewIntResult(1, nil)).Times(1)
 
 	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			return &models.Book{ID: 9, OwnerID: 3}, nil
+		},
 		deleteFn: func(id uint) error {
 			assert.Equal(t, uint(9), id)
 			return nil
 		},
 	}
 	svc := NewBookService(store, mockRedis)
-	assert.NoError(t, svc.DeleteBook(context.Background(), 9))
+	assert.NoError(t, svc.DeleteBook(context.Background(), 3, 9))
+}
+
+func TestUpdateBookWrongOwner(t *testing.T) {
+	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			return &models.Book{ID: 1, OwnerID: 1}, nil
+		},
+	}
+	svc := NewBookService(store, nil)
+	_, err := svc.UpdateBook(context.Background(), 2, 1, "x", "y")
+	assert.ErrorIs(t, err, ErrBookForbidden)
+}
+
+func TestDeleteBookWrongOwner(t *testing.T) {
+	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			return &models.Book{ID: 1, OwnerID: 1}, nil
+		},
+	}
+	svc := NewBookService(store, nil)
+	assert.ErrorIs(t, svc.DeleteBook(context.Background(), 9, 1), ErrBookForbidden)
 }

--- a/pkg/service/user_service.go
+++ b/pkg/service/user_service.go
@@ -16,12 +16,12 @@ import (
 
 // Sentinel errors for login / registration.
 var (
-	ErrInvalidLogin      = errors.New("service: invalid username or password")
-	ErrLoginDB           = errors.New("service: login database error")
-	ErrTokenGenerate     = errors.New("service: token generation failed")
-	ErrRegisterConflict  = errors.New("service: username already taken")
-	ErrRegisterHash      = errors.New("service: password hash failed")
-	ErrRegisterSave      = errors.New("service: could not save user")
+	ErrInvalidLogin     = errors.New("service: invalid username or password")
+	ErrLoginDB          = errors.New("service: login database error")
+	ErrTokenGenerate    = errors.New("service: token generation failed")
+	ErrRegisterConflict = errors.New("service: username already taken")
+	ErrRegisterHash     = errors.New("service: password hash failed")
+	ErrRegisterSave     = errors.New("service: could not save user")
 )
 
 // UserService handles authentication use-cases without Gin.
@@ -46,7 +46,7 @@ func (s *UserService) Login(_ context.Context, username, password string) (token
 	if err := bcrypt.CompareHashAndPassword([]byte(dbUser.Password), []byte(password)); err != nil {
 		return "", ErrInvalidLogin
 	}
-	tok, err := auth.GenerateToken(dbUser.Username)
+	tok, err := auth.GenerateToken(dbUser.Username, dbUser.ID)
 	if err != nil {
 		return "", fmtError(ErrTokenGenerate, err)
 	}

--- a/pkg/service/user_service_test.go
+++ b/pkg/service/user_service_test.go
@@ -79,7 +79,7 @@ func TestUserServiceLoginSuccess(t *testing.T) {
 	assert.NoError(t, err)
 	store := &fakeUserStore{
 		findFn: func(username string) (*models.User, error) {
-			return &models.User{Username: "alice", Password: string(hash)}, nil
+			return &models.User{ID: 100, Username: "alice", Password: string(hash)}, nil
 		},
 	}
 	svc := NewUserService(store)


### PR DESCRIPTION
## Summary

Closes [#117](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/117).

- `models.Book` gains `owner_id` (indexed, required). New rows get the authenticated user id on POST /books.
- JWTs now include `user_id` (login uses `users.id`). `auth.GenerateToken(username, userID)` requires a non-zero id; middleware exposes `middleware.ContextUserID` and rejects tokens with `user_id` missing or zero (legacy tokens must re-login).
- `BookService` checks ownership before update/delete; `ErrBookForbidden` maps to HTTP **403** with `{"error":"forbidden"}`. Missing auth context on mutating handlers returns **401**.
- List/get book endpoints unchanged (still API-key scoped as before).
- Swagger regenerated (`make setup`).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking:** JWT payload and `GenerateToken` signature changed; existing JWTs without `user_id` are rejected. Clients must log in again. Direct callers of `CreateBook` / `UpdateBook` / `DeleteBook` on `BookService` need the new parameters.

## How to test

```bash
go test ./... -race
go vet ./...
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] Swagger regenerated and `docs/` updated
- [ ] Env / compose changes N/A
- [x] No new secrets committed

## Related issues

Closes #117


Made with [Cursor](https://cursor.com)