### PR TITLE
feat: PUT full replace and PATCH partial update for books (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ http://localhost:8001/swagger/index.html
 - `GET /api/v1/books`: Get all books.
 - `GET /api/v1/books/:id`: Get a single book by ID.
 - `POST /api/v1/books`: Create a new book.
-- `PUT /api/v1/books/:id`: Update a book.
+- `PUT /api/v1/books/:id`: Replace a book's title and author (both fields required in the JSON body).
+- `PATCH /api/v1/books/:id`: Partially update a book (send only the fields to change; at least one of `title` or `author` is required).
 - `DELETE /api/v1/books/:id`: Delete a book.
 - `POST /api/v1/login`: Login.
 - `POST /api/v1/register`: Register a new user.
@@ -194,7 +195,7 @@ http://localhost:8001/swagger/index.html
 
 Under **`/api/v1`**, every route **except** `GET /api/v1/` (health) requires the **`X-API-Key`** header matching **`API_SECRET_KEY`** (service-to-service gate).
 
-Book **mutations** (`POST`, `PUT`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain via `/api/v1/register` and `/api/v1/login`). Book **reads** (`GET` list and `GET` by id) require the API key only.
+Book **mutations** (`POST`, `PUT`, `PATCH`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain via `/api/v1/register` and `/api/v1/login`). Book **reads** (`GET` list and `GET` by id) require the API key only.
 
 ```bash
 curl -H "X-API-Key: <YOUR_API_KEY>" http://localhost:8001/api/v1/books
@@ -272,7 +273,7 @@ The tests will perform the following actions:
 2. Create a new book in the system.
 3. Retrieve all books and verify the created book is present.
 4. Retrieve a specific book by its ID.
-5. Update the book's details.
+5. Replace the book's title and author via `PUT`, and patch the title only via `PATCH`.
 6. Delete the book and verify it is no longer accessible.
 
 Each test includes assertions to ensure that the API behaves as expected.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -209,7 +209,7 @@ const docTemplate = `{
                         "JwtAuth": []
                     }
                 ],
-                "description": "Update the book details for the given ID",
+                "description": "Replaces both title and author. Use PATCH for partial updates.",
                 "consumes": [
                     "application/json"
                 ],
@@ -219,7 +219,7 @@ const docTemplate = `{
                 "tags": [
                     "books"
                 ],
-                "summary": "Update a book by ID",
+                "summary": "Replace a book by ID (PUT)",
                 "parameters": [
                     {
                         "type": "string",
@@ -229,12 +229,12 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "Update book object",
+                        "description": "Full book fields",
                         "name": "input",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UpdateBook"
+                            "$ref": "#/definitions/models.ReplaceBook"
                         }
                     }
                 ],
@@ -306,6 +306,83 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "Successfully deleted book"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "book not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
+                    }
+                ],
+                "description": "Updates only fields present in the JSON body (at least one of title or author).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Partially update a book by ID (PATCH)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to change",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.PatchBook"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated book",
+                        "schema": {
+                            "$ref": "#/definitions/models.Book"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
                     },
                     "401": {
                         "description": "Unauthorized",
@@ -503,8 +580,23 @@ const docTemplate = `{
                 }
             }
         },
-        "models.UpdateBook": {
+        "models.PatchBook": {
             "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.ReplaceBook": {
+            "type": "object",
+            "required": [
+                "author",
+                "title"
+            ],
             "properties": {
                 "author": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -203,7 +203,7 @@
                         "JwtAuth": []
                     }
                 ],
-                "description": "Update the book details for the given ID",
+                "description": "Replaces both title and author. Use PATCH for partial updates.",
                 "consumes": [
                     "application/json"
                 ],
@@ -213,7 +213,7 @@
                 "tags": [
                     "books"
                 ],
-                "summary": "Update a book by ID",
+                "summary": "Replace a book by ID (PUT)",
                 "parameters": [
                     {
                         "type": "string",
@@ -223,12 +223,12 @@
                         "required": true
                     },
                     {
-                        "description": "Update book object",
+                        "description": "Full book fields",
                         "name": "input",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UpdateBook"
+                            "$ref": "#/definitions/models.ReplaceBook"
                         }
                     }
                 ],
@@ -300,6 +300,83 @@
                 "responses": {
                     "204": {
                         "description": "Successfully deleted book"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "book not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {
+                        "JwtAuth": []
+                    }
+                ],
+                "description": "Updates only fields present in the JSON body (at least one of title or author).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "books"
+                ],
+                "summary": "Partially update a book by ID (PATCH)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Book ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to change",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.PatchBook"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully updated book",
+                        "schema": {
+                            "$ref": "#/definitions/models.Book"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
                     },
                     "401": {
                         "description": "Unauthorized",
@@ -497,8 +574,23 @@
                 }
             }
         },
-        "models.UpdateBook": {
+        "models.PatchBook": {
             "type": "object",
+            "properties": {
+                "author": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.ReplaceBook": {
+            "type": "object",
+            "required": [
+                "author",
+                "title"
+            ],
             "properties": {
                 "author": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -35,12 +35,22 @@ definitions:
     - password
     - username
     type: object
-  models.UpdateBook:
+  models.PatchBook:
     properties:
       author:
         type: string
       title:
         type: string
+    type: object
+  models.ReplaceBook:
+    properties:
+      author:
+        type: string
+      title:
+        type: string
+    required:
+    - author
+    - title
     type: object
 externalDocs:
   description: OpenAPI
@@ -212,22 +222,23 @@ paths:
       summary: Find a book by ID
       tags:
       - books
-    put:
+    patch:
       consumes:
       - application/json
-      description: Update the book details for the given ID
+      description: Updates only fields present in the JSON body (at least one of title
+        or author).
       parameters:
       - description: Book ID
         in: path
         name: id
         required: true
         type: string
-      - description: Update book object
+      - description: Fields to change
         in: body
         name: input
         required: true
         schema:
-          $ref: '#/definitions/models.UpdateBook'
+          $ref: '#/definitions/models.PatchBook'
       produces:
       - application/json
       responses:
@@ -258,7 +269,56 @@ paths:
       security:
       - ApiKeyAuth: []
       - JwtAuth: []
-      summary: Update a book by ID
+      summary: Partially update a book by ID (PATCH)
+      tags:
+      - books
+    put:
+      consumes:
+      - application/json
+      description: Replaces both title and author. Use PATCH for partial updates.
+      parameters:
+      - description: Book ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Full book fields
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/models.ReplaceBook'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully updated book
+          schema:
+            $ref: '#/definitions/models.Book'
+        "400":
+          description: Bad Request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
+        "404":
+          description: book not found
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
+      security:
+      - ApiKeyAuth: []
+      - JwtAuth: []
+      summary: Replace a book by ID (PUT)
       tags:
       - books
   /login:

--- a/pkg/api/book_routes_auth_test.go
+++ b/pkg/api/book_routes_auth_test.go
@@ -29,6 +29,7 @@ func testBookWriteMiddlewareStack(t *testing.T) *gin.Engine {
 		}
 	}
 	r.PUT("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
+	r.PATCH("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
 	r.DELETE("/api/v1/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), ok)
 	return r
 }
@@ -88,6 +89,19 @@ func TestBookWriteRoutesRequireAPIKeyAndJWT(t *testing.T) {
 		{
 			name:       "put valid api key and jwt",
 			method:     http.MethodPut,
+			apiKeyHdr:  apiKey,
+			authzHdr:   "Bearer " + token,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "patch missing api key",
+			method:     http.MethodPatch,
+			wantStatus: http.StatusUnauthorized,
+			wantErrSub: "Unauthorized",
+		},
+		{
+			name:       "patch valid api key and jwt",
+			method:     http.MethodPatch,
 			apiKeyHdr:  apiKey,
 			authzHdr:   "Bearer " + token,
 			wantStatus: http.StatusOK,

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -28,6 +28,7 @@ type BookHandler interface {
 	CreateBook(c *gin.Context)
 	FindBook(c *gin.Context)
 	UpdateBook(c *gin.Context)
+	PatchBook(c *gin.Context)
 	DeleteBook(c *gin.Context)
 }
 
@@ -206,15 +207,15 @@ func (h *bookHandler) FindBook(c *gin.Context) {
 }
 
 // UpdateBook godoc
-// @Summary Update a book by ID
-// @Description Update the book details for the given ID
+// @Summary Replace a book by ID (PUT)
+// @Description Replaces both title and author. Use PATCH for partial updates.
 // @Tags books
 // @Security ApiKeyAuth
 // @Security JwtAuth
 // @Accept  json
 // @Produce  json
 // @Param id path string true "Book ID"
-// @Param input body models.UpdateBook true "Update book object"
+// @Param input body models.ReplaceBook true "Full book fields"
 // @Success 200 {object} models.Book "Successfully updated book"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
@@ -228,7 +229,7 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
 		return
 	}
-	var input models.UpdateBook
+	var input models.ReplaceBook
 	id, ok := parseIDParam(c)
 	if !ok {
 		return
@@ -237,7 +238,59 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	book, err := h.svc.UpdateBook(c.Request.Context(), actorID, id, input.Title, input.Author)
+	book, err := h.svc.ReplaceBook(c.Request.Context(), actorID, id, input.Title, input.Author)
+	if err != nil {
+		if repository.IsBookNotFound(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			return
+		}
+		if errors.Is(err, service.ErrBookForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update book"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": book})
+}
+
+// PatchBook godoc
+// @Summary Partially update a book by ID (PATCH)
+// @Description Updates only fields present in the JSON body (at least one of title or author).
+// @Tags books
+// @Security ApiKeyAuth
+// @Security JwtAuth
+// @Accept  json
+// @Produce  json
+// @Param id path string true "Book ID"
+// @Param input body models.PatchBook true "Fields to change"
+// @Success 200 {object} models.Book "Successfully updated book"
+// @Failure 400 {string} string "Bad Request"
+// @Failure 401 {string} string "Unauthorized"
+// @Failure 403 {string} string "Forbidden"
+// @Failure 404 {string} string "book not found"
+// @Failure 500 {string} string "Internal Server Error"
+// @Router /books/{id} [patch]
+func (h *bookHandler) PatchBook(c *gin.Context) {
+	actorID, ok := contextUserID(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	id, ok := parseIDParam(c)
+	if !ok {
+		return
+	}
+	var input models.PatchBook
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if input.Title == nil && input.Author == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one of title or author is required"})
+		return
+	}
+	book, err := h.svc.PatchBook(c.Request.Context(), actorID, id, input.Title, input.Author)
 	if err != nil {
 		if repository.IsBookNotFound(err) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -315,7 +315,7 @@ func TestUpdateBookInvalidID(t *testing.T) {
 	r := gin.Default()
 	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
-	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
+	updateInput := models.ReplaceBook{Title: "New Title", Author: "New Author"}
 	requestBody, _ := json.Marshal(updateInput)
 
 	w := httptest.NewRecorder()
@@ -338,7 +338,7 @@ func TestUpdateBookNotFound(t *testing.T) {
 	r := gin.Default()
 	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
-	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
+	updateInput := models.ReplaceBook{Title: "New Title", Author: "New Author"}
 	requestBody, _ := json.Marshal(updateInput)
 
 	mockStore.EXPECT().FirstByID(uint(1)).Return(nil, gorm.ErrRecordNotFound)
@@ -367,7 +367,7 @@ func TestUpdateBookForbiddenWrongOwner(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.PUT("/book/:id", withBookActor(2), h.UpdateBook)
-	body, err := json.Marshal(models.UpdateBook{Title: "n", Author: "n"})
+	body, err := json.Marshal(models.ReplaceBook{Title: "n", Author: "n"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -397,6 +397,65 @@ func TestUpdateBookBindError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, w.Body.String(), "error")
+}
+
+func TestPatchBookRequiresAtLeastOneField(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	h := NewBookHandler(repository.NewMockBookPersistence(ctrl), nil)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.PATCH("/book/:id", withBookActor(1), h.PatchBook)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/book/1", bytes.NewBufferString("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "at least one")
+}
+
+func TestPutBookRequiresTitleAndAuthor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	h := NewBookHandler(repository.NewMockBookPersistence(ctrl), nil)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/book/1", bytes.NewBufferString(`{"title":"only-title"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPatchBookTitleOnly(t *testing.T) {
+	// Isolated DB: shared in-memory SQLite is reused across tests and races under parallel pkg/api runs.
+	dbPath := filepath.Join(t.TempDir(), "patch_book_title.sqlite")
+	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.Book{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Book{OwnerID: 1, Title: "old", Author: "same"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	h := NewBookHandler(repository.NewGormBookStore(db), nil)
+	gin.SetMode(gin.TestMode)
+	r := gin.Default()
+	r.PATCH("/book/:id", withBookActor(1), h.PatchBook)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPatch, "/book/1", bytes.NewBufferString(`{"title":"new-title"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp struct {
+		Data models.Book `json:"data"`
+	}
+	assert.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "new-title", resp.Data.Title)
+	assert.Equal(t, "same", resp.Data.Author)
 }
 
 func TestFindBooksDatabaseError(t *testing.T) {
@@ -470,7 +529,7 @@ func TestUpdateBookDatabaseErrorOnUpdates(t *testing.T) {
 	r := gin.Default()
 	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
-	updateInput := models.UpdateBook{Title: "New Title", Author: "New Author"}
+	updateInput := models.ReplaceBook{Title: "New Title", Author: "New Author"}
 	requestBody, err := json.Marshal(updateInput)
 	if err != nil {
 		t.Fatal(err)
@@ -509,7 +568,7 @@ func TestUpdateBookBumpsListCacheGen(t *testing.T) {
 	r := gin.Default()
 	r.PUT("/book/:id", withBookActor(1), h.UpdateBook)
 
-	body, err := json.Marshal(models.UpdateBook{Title: "n", Author: "n"})
+	body, err := json.Marshal(models.ReplaceBook{Title: "n", Author: "n"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -53,6 +53,7 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db *gorm.D
 		v1.POST("/books", middleware.APIKeyAuth(), middleware.JWTAuth(), books.CreateBook)
 		v1.GET("/books/:id", middleware.APIKeyAuth(), books.FindBook)
 		v1.PUT("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), books.UpdateBook)
+		v1.PATCH("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), books.PatchBook)
 		v1.DELETE("/books/:id", middleware.APIKeyAuth(), middleware.JWTAuth(), books.DeleteBook)
 
 		v1.POST("/login", middleware.APIKeyAuth(), users.LoginHandler)

--- a/pkg/models/book.go
+++ b/pkg/models/book.go
@@ -16,7 +16,15 @@ type CreateBook struct {
 	Author string `json:"author" binding:"required"`
 }
 
-type UpdateBook struct {
-	Title  string `json:"title"`
-	Author string `json:"author"`
+// ReplaceBook is the JSON body for PUT /books/:id (full replace of title and author).
+type ReplaceBook struct {
+	Title  string `json:"title" binding:"required"`
+	Author string `json:"author" binding:"required"`
+}
+
+// PatchBook is the JSON body for PATCH /books/:id. Omitted JSON keys leave the field
+// unchanged; the request must set at least one of title or author.
+type PatchBook struct {
+	Title  *string `json:"title,omitempty"`
+	Author *string `json:"author,omitempty"`
 }

--- a/pkg/repository/book.go
+++ b/pkg/repository/book.go
@@ -10,5 +10,6 @@ type BookPersistence interface {
 	Create(book *models.Book) error
 	FirstByID(id uint) (*models.Book, error)
 	UpdateFields(id uint, title, author string) (*models.Book, error)
+	PatchFields(id uint, title, author *string) (*models.Book, error)
 	DeleteByID(id uint) error
 }

--- a/pkg/repository/book_gorm.go
+++ b/pkg/repository/book_gorm.go
@@ -49,6 +49,34 @@ func (s *GormBookStore) UpdateFields(id uint, title, author string) (*models.Boo
 	return book, nil
 }
 
+// PatchFields updates only non-nil pointer fields (partial update).
+func (s *GormBookStore) PatchFields(id uint, title, author *string) (*models.Book, error) {
+	book, err := s.FirstByID(id)
+	if err != nil {
+		return nil, err
+	}
+	updates := map[string]interface{}{}
+	if title != nil {
+		updates["title"] = *title
+	}
+	if author != nil {
+		updates["author"] = *author
+	}
+	if len(updates) == 0 {
+		return book, nil
+	}
+	if err := s.db.Model(book).Updates(updates).Error; err != nil {
+		return nil, err
+	}
+	if title != nil {
+		book.Title = *title
+	}
+	if author != nil {
+		book.Author = *author
+	}
+	return book, nil
+}
+
 func (s *GormBookStore) DeleteByID(id uint) error {
 	book, err := s.FirstByID(id)
 	if err != nil {

--- a/pkg/repository/book_gorm_test.go
+++ b/pkg/repository/book_gorm_test.go
@@ -97,6 +97,40 @@ func TestGormBookStoreUpdateFieldsNotFound(t *testing.T) {
 	assert.True(t, IsBookNotFound(err))
 }
 
+func TestGormBookStorePatchFieldsTitleOnly(t *testing.T) {
+	db := testBookDB(t)
+	s := NewGormBookStore(db)
+	b := &models.Book{OwnerID: 1, Title: "orig", Author: "keep"}
+	assert.NoError(t, s.Create(b))
+	newTitle := "patched"
+	out, err := s.PatchFields(b.ID, &newTitle, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "patched", out.Title)
+	assert.Equal(t, "keep", out.Author)
+	reloaded, err := s.FirstByID(b.ID)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "patched", reloaded.Title)
+	assert.Equal(t, "keep", reloaded.Author)
+}
+
+func TestGormBookStorePatchFieldsAuthorOnly(t *testing.T) {
+	db := testBookDB(t)
+	s := NewGormBookStore(db)
+	b := &models.Book{OwnerID: 1, Title: "keep", Author: "orig"}
+	assert.NoError(t, s.Create(b))
+	newAuthor := "new-author"
+	out, err := s.PatchFields(b.ID, nil, &newAuthor)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "keep", out.Title)
+	assert.Equal(t, "new-author", out.Author)
+}
+
 func TestGormBookStoreDeleteByID(t *testing.T) {
 	db := testBookDB(t)
 	s := NewGormBookStore(db)

--- a/pkg/repository/mock_persistence.go
+++ b/pkg/repository/mock_persistence.go
@@ -92,6 +92,21 @@ func (mr *MockBookPersistenceMockRecorder) List(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockBookPersistence)(nil).List), arg0, arg1)
 }
 
+// PatchFields mocks base method.
+func (m *MockBookPersistence) PatchFields(arg0 uint, arg1, arg2 *string) (*models.Book, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchFields", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*models.Book)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchFields indicates an expected call of PatchFields.
+func (mr *MockBookPersistenceMockRecorder) PatchFields(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchFields", reflect.TypeOf((*MockBookPersistence)(nil).PatchFields), arg0, arg1, arg2)
+}
+
 // UpdateFields mocks base method.
 func (m *MockBookPersistence) UpdateFields(arg0 uint, arg1, arg2 string) (*models.Book, error) {
 	m.ctrl.T.Helper()

--- a/pkg/service/book_service.go
+++ b/pkg/service/book_service.go
@@ -117,8 +117,8 @@ func (s *BookService) GetBook(_ context.Context, id uint) (*models.Book, error) 
 	return s.store.FirstByID(id)
 }
 
-// UpdateBook updates fields when actorID owns the book, then bumps list cache generation.
-func (s *BookService) UpdateBook(ctx context.Context, actorID, id uint, title, author string) (*models.Book, error) {
+// ReplaceBook replaces title and author when actorID owns the book (PUT semantics).
+func (s *BookService) ReplaceBook(ctx context.Context, actorID, id uint, title, author string) (*models.Book, error) {
 	b, err := s.store.FirstByID(id)
 	if err != nil {
 		return nil, err
@@ -127,6 +127,23 @@ func (s *BookService) UpdateBook(ctx context.Context, actorID, id uint, title, a
 		return nil, ErrBookForbidden
 	}
 	book, err := s.store.UpdateFields(id, title, author)
+	if err != nil {
+		return nil, err
+	}
+	s.bumpListCacheGeneration(ctx)
+	return book, nil
+}
+
+// PatchBook applies a partial update for any non-nil title/author pointers (PATCH semantics).
+func (s *BookService) PatchBook(ctx context.Context, actorID, id uint, title, author *string) (*models.Book, error) {
+	b, err := s.store.FirstByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if b.OwnerID != actorID {
+		return nil, ErrBookForbidden
+	}
+	book, err := s.store.PatchFields(id, title, author)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/book_service_test.go
+++ b/pkg/service/book_service_test.go
@@ -20,6 +20,7 @@ type fakeBookStore struct {
 	createFn func(book *models.Book) error
 	firstFn  func(id uint) (*models.Book, error)
 	updateFn func(id uint, title, author string) (*models.Book, error)
+	patchFn  func(id uint, title, author *string) (*models.Book, error)
 	deleteFn func(id uint) error
 }
 
@@ -47,6 +48,13 @@ func (f *fakeBookStore) FirstByID(id uint) (*models.Book, error) {
 func (f *fakeBookStore) UpdateFields(id uint, title, author string) (*models.Book, error) {
 	if f.updateFn != nil {
 		return f.updateFn(id, title, author)
+	}
+	return nil, nil
+}
+
+func (f *fakeBookStore) PatchFields(id uint, title, author *string) (*models.Book, error) {
+	if f.patchFn != nil {
+		return f.patchFn(id, title, author)
 	}
 	return nil, nil
 }
@@ -213,7 +221,7 @@ func TestGetBookDelegates(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestUpdateBookBumpsGeneration(t *testing.T) {
+func TestReplaceBookBumpsGeneration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRedis := cache.NewMockCache(ctrl)
@@ -232,9 +240,35 @@ func TestUpdateBookBumpsGeneration(t *testing.T) {
 		},
 	}
 	svc := NewBookService(store, mockRedis)
-	got, err := svc.UpdateBook(context.Background(), 5, 1, "n", "m")
+	got, err := svc.ReplaceBook(context.Background(), 5, 1, "n", "m")
 	assert.NoError(t, err)
 	assert.Equal(t, updated, got)
+}
+
+func TestPatchBookBumpsGenerationTitleOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRedis := cache.NewMockCache(ctrl)
+	mockRedis.EXPECT().Incr(gomock.Any(), BooksListCacheGenKey).Return(redis.NewIntResult(3, nil)).Times(1)
+
+	newTitle := "patched"
+	out := &models.Book{ID: 2, OwnerID: 7, Title: newTitle, Author: "kept"}
+	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			return &models.Book{ID: 2, OwnerID: 7, Title: "old", Author: "kept"}, nil
+		},
+		patchFn: func(id uint, title, author *string) (*models.Book, error) {
+			assert.Equal(t, uint(2), id)
+			assert.NotNil(t, title)
+			assert.Nil(t, author)
+			assert.Equal(t, newTitle, *title)
+			return out, nil
+		},
+	}
+	svc := NewBookService(store, mockRedis)
+	got, err := svc.PatchBook(context.Background(), 7, 2, &newTitle, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, out, got)
 }
 
 func TestDeleteBookBumpsGeneration(t *testing.T) {
@@ -256,14 +290,26 @@ func TestDeleteBookBumpsGeneration(t *testing.T) {
 	assert.NoError(t, svc.DeleteBook(context.Background(), 3, 9))
 }
 
-func TestUpdateBookWrongOwner(t *testing.T) {
+func TestReplaceBookWrongOwner(t *testing.T) {
 	store := &fakeBookStore{
 		firstFn: func(id uint) (*models.Book, error) {
 			return &models.Book{ID: 1, OwnerID: 1}, nil
 		},
 	}
 	svc := NewBookService(store, nil)
-	_, err := svc.UpdateBook(context.Background(), 2, 1, "x", "y")
+	_, err := svc.ReplaceBook(context.Background(), 2, 1, "x", "y")
+	assert.ErrorIs(t, err, ErrBookForbidden)
+}
+
+func TestPatchBookWrongOwner(t *testing.T) {
+	x := "t"
+	store := &fakeBookStore{
+		firstFn: func(id uint) (*models.Book, error) {
+			return &models.Book{ID: 1, OwnerID: 1}, nil
+		},
+	}
+	svc := NewBookService(store, nil)
+	_, err := svc.PatchBook(context.Background(), 2, 1, &x, nil)
 	assert.ErrorIs(t, err, ErrBookForbidden)
 }
 

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -74,7 +74,7 @@ def get_book(book_id, jwt_token):
     return response.json()
 
 
-# Update a book
+# Update a book (PUT: both title and author required)
 def update_book(book_id, jwt_token):
     url = f"{BASE_URL}/books/{book_id}"
     auth_headers = {**headers, "Authorization": f"Bearer {jwt_token}"}
@@ -82,6 +82,17 @@ def update_book(book_id, jwt_token):
     response = requests.put(url, headers=auth_headers, data=data)
 
     assert response.status_code == 200, f"Failed to update book: {response.status_code}"
+    return response.json()
+
+
+# Partial update (PATCH: at least one field)
+def patch_book(book_id, jwt_token, payload: dict):
+    url = f"{BASE_URL}/books/{book_id}"
+    auth_headers = {**headers, "Authorization": f"Bearer {jwt_token}"}
+    data = json.dumps(payload)
+    response = requests.patch(url, headers=auth_headers, data=data)
+
+    assert response.status_code == 200, f"Failed to patch book: {response.status_code}"
     return response.json()
 
 
@@ -126,6 +137,15 @@ def test_update_book(jwt_token):
     updated_book = update_book(book_id, jwt_token)
     assert updated_book["data"]["author"] == "John Smith", "Book author not updated"
     assert updated_book["data"]["title"] == "Updated Book Title", "Book title not updated"
+
+
+def test_patch_book_title_only(jwt_token):
+    book = create_book(jwt_token)
+    book_id = book["data"]["id"]
+    orig_author = book["data"]["author"]
+    patched = patch_book(book_id, jwt_token, {"title": "Patched Title Only"})
+    assert patched["data"]["title"] == "Patched Title Only"
+    assert patched["data"]["author"] == orig_author
 
 
 def test_delete_book(jwt_token):


### PR DESCRIPTION
## Summary

This change separates book updates into **PUT** (full replace of `title` and `author`, both required) and **PATCH** (partial update: only fields present in the JSON are applied; at least one of `title` or `author` is required). The repository gains `PatchFields`, the service exposes `ReplaceBook` / `PatchBook`, and `PATCH /api/v1/books/:id` is registered alongside the existing PUT route. Swagger and README are updated; Python E2E covers a title-only PATCH.

Clients that previously used PUT with a single field must switch that call to **PATCH** or send both fields on PUT.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Breaking change:** `PUT /api/v1/books/:id` now rejects bodies that omit `title` or `author`. Partial updates belong on `PATCH /api/v1/books/:id`.

## How to test

Steps run locally:

```bash
go test ./... -race
go vet ./...
make setup
```

Optional with a running API:

```bash
# optional: local stack
# make up

# optional: Python E2E (see README; requires BASE_URL and API_KEY)
# pytest -v tests/e2e.py
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [x] If you added or renamed **environment variables**: README and/or `.env` examples are updated (N/A — no new env vars)
- [x] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds (N/A — unchanged)
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #118
