### PR TITLE
refactor: centralize JSON error responses (#119)

### DIFF
--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"golang-rest-api-template/pkg/cache"
+	"golang-rest-api-template/pkg/httperr"
 	"golang-rest-api-template/pkg/middleware"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
@@ -48,7 +49,7 @@ func parseIDParam(c *gin.Context) (uint, bool) {
 	value := c.Param("id")
 	id, err := strconv.ParseUint(value, 10, strconv.IntSize)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid id format"})
+		httperr.Write(c, http.StatusBadRequest, "Invalid id format")
 		return 0, false
 	}
 	return uint(id), true
@@ -60,20 +61,20 @@ func parseOffsetLimit(c *gin.Context) (offset, limit int, ok bool) {
 
 	o, err := strconv.Atoi(offsetQuery)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid offset format"})
+		httperr.Write(c, http.StatusBadRequest, "Invalid offset format")
 		return 0, 0, false
 	}
 	l, err := strconv.Atoi(limitQuery)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid limit format"})
+		httperr.Write(c, http.StatusBadRequest, "Invalid limit format")
 		return 0, 0, false
 	}
 	if o < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "offset must be >= 0"})
+		httperr.Write(c, http.StatusBadRequest, "offset must be >= 0")
 		return 0, 0, false
 	}
 	if l < findBooksMinLimit {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "limit must be at least 1"})
+		httperr.Write(c, http.StatusBadRequest, "limit must be at least 1")
 		return 0, 0, false
 	}
 	if l > findBooksMaxLimit {
@@ -131,15 +132,15 @@ func (h *bookHandler) FindBooks(c *gin.Context) {
 	if err != nil {
 		switch {
 		case errors.Is(err, service.ErrListBooksDB):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
+			httperr.Write(c, http.StatusInternalServerError, "Failed to list books")
 		case errors.Is(err, service.ErrListBooksMarshal):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to marshal data"})
+			httperr.Write(c, http.StatusInternalServerError, "Failed to marshal data")
 		case errors.Is(err, service.ErrListBooksRedis):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set cache"})
+			httperr.Write(c, http.StatusInternalServerError, "Failed to set cache")
 		case errors.Is(err, service.ErrListBooksUnmarshal):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to unmarshal cached data"})
+			httperr.Write(c, http.StatusInternalServerError, "Failed to unmarshal cached data")
 		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list books"})
+			httperr.Write(c, http.StatusInternalServerError, "Failed to list books")
 		}
 		return
 	}
@@ -163,17 +164,17 @@ func (h *bookHandler) FindBooks(c *gin.Context) {
 func (h *bookHandler) CreateBook(c *gin.Context) {
 	ownerID, ok := contextUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		httperr.Write(c, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
 	var input models.CreateBook
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		httperr.Write(c, http.StatusBadRequest, err.Error())
 		return
 	}
 	book, err := h.svc.CreateBook(c.Request.Context(), ownerID, input.Title, input.Author)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book"})
+		httperr.Write(c, http.StatusInternalServerError, "Failed to create book")
 		return
 	}
 	c.JSON(http.StatusCreated, gin.H{"data": book})
@@ -197,10 +198,10 @@ func (h *bookHandler) FindBook(c *gin.Context) {
 	book, err := h.svc.GetBook(c.Request.Context(), id)
 	if err != nil {
 		if repository.IsBookNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			httperr.Write(c, http.StatusNotFound, "book not found")
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load book"})
+		httperr.Write(c, http.StatusInternalServerError, "Failed to load book")
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": book})
@@ -226,7 +227,7 @@ func (h *bookHandler) FindBook(c *gin.Context) {
 func (h *bookHandler) UpdateBook(c *gin.Context) {
 	actorID, ok := contextUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		httperr.Write(c, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
 	var input models.ReplaceBook
@@ -235,20 +236,20 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 		return
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		httperr.Write(c, http.StatusBadRequest, err.Error())
 		return
 	}
 	book, err := h.svc.ReplaceBook(c.Request.Context(), actorID, id, input.Title, input.Author)
 	if err != nil {
 		if repository.IsBookNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			httperr.Write(c, http.StatusNotFound, "book not found")
 			return
 		}
 		if errors.Is(err, service.ErrBookForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			httperr.Write(c, http.StatusForbidden, "forbidden")
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update book"})
+		httperr.Write(c, http.StatusInternalServerError, "Failed to update book")
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": book})
@@ -274,7 +275,7 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 func (h *bookHandler) PatchBook(c *gin.Context) {
 	actorID, ok := contextUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		httperr.Write(c, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
 	id, ok := parseIDParam(c)
@@ -283,24 +284,24 @@ func (h *bookHandler) PatchBook(c *gin.Context) {
 	}
 	var input models.PatchBook
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		httperr.Write(c, http.StatusBadRequest, err.Error())
 		return
 	}
 	if input.Title == nil && input.Author == nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one of title or author is required"})
+		httperr.Write(c, http.StatusBadRequest, "at least one of title or author is required")
 		return
 	}
 	book, err := h.svc.PatchBook(c.Request.Context(), actorID, id, input.Title, input.Author)
 	if err != nil {
 		if repository.IsBookNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			httperr.Write(c, http.StatusNotFound, "book not found")
 			return
 		}
 		if errors.Is(err, service.ErrBookForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			httperr.Write(c, http.StatusForbidden, "forbidden")
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update book"})
+		httperr.Write(c, http.StatusInternalServerError, "Failed to update book")
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": book})
@@ -323,7 +324,7 @@ func (h *bookHandler) PatchBook(c *gin.Context) {
 func (h *bookHandler) DeleteBook(c *gin.Context) {
 	actorID, ok := contextUserID(c)
 	if !ok {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		httperr.Write(c, http.StatusUnauthorized, "Unauthorized")
 		return
 	}
 	id, ok := parseIDParam(c)
@@ -332,14 +333,14 @@ func (h *bookHandler) DeleteBook(c *gin.Context) {
 	}
 	if err := h.svc.DeleteBook(c.Request.Context(), actorID, id); err != nil {
 		if repository.IsBookNotFound(err) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "book not found"})
+			httperr.Write(c, http.StatusNotFound, "book not found")
 			return
 		}
 		if errors.Is(err, service.ErrBookForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+			httperr.Write(c, http.StatusForbidden, "forbidden")
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete book"})
+		httperr.Write(c, http.StatusInternalServerError, "Failed to delete book")
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"golang-rest-api-template/pkg/httperr"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 	"golang-rest-api-template/pkg/service"
@@ -45,18 +46,18 @@ func NewUserHandler(store repository.UserPersistence) *userHandler {
 func (h *userHandler) LoginHandler(c *gin.Context) {
 	var incoming models.LoginUser
 	if err := c.ShouldBindJSON(&incoming); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		httperr.Write(c, http.StatusBadRequest, err.Error())
 		return
 	}
 	token, err := h.svc.Login(c.Request.Context(), incoming.Username, incoming.Password)
 	if err != nil {
 		switch {
 		case errors.Is(err, service.ErrInvalidLogin):
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid username or password"})
+			httperr.Write(c, http.StatusUnauthorized, "Invalid username or password")
 		case errors.Is(err, service.ErrLoginDB), errors.Is(err, service.ErrTokenGenerate):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
+			httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
 		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
+			httperr.Write(c, http.StatusInternalServerError, "Internal Server Error")
 		}
 		return
 	}
@@ -80,17 +81,17 @@ func (h *userHandler) LoginHandler(c *gin.Context) {
 func (h *userHandler) RegisterHandler(c *gin.Context) {
 	var user models.LoginUser
 	if err := c.ShouldBindJSON(&user); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		httperr.Write(c, http.StatusBadRequest, err.Error())
 		return
 	}
 	if err := h.svc.Register(c.Request.Context(), user.Username, user.Password); err != nil {
 		switch {
 		case errors.Is(err, service.ErrRegisterConflict):
-			c.JSON(http.StatusConflict, gin.H{"error": "username already taken"})
+			httperr.Write(c, http.StatusConflict, "username already taken")
 		case errors.Is(err, service.ErrRegisterHash), errors.Is(err, service.ErrRegisterSave):
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not save user"})
+			httperr.Write(c, http.StatusInternalServerError, "Could not save user")
 		default:
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not save user"})
+			httperr.Write(c, http.StatusInternalServerError, "Could not save user")
 		}
 		return
 	}

--- a/pkg/httperr/httperr.go
+++ b/pkg/httperr/httperr.go
@@ -1,0 +1,26 @@
+package httperr
+
+import "github.com/gin-gonic/gin"
+
+// ErrorBody is the standard JSON error envelope for this API: {"error":"..."}.
+type ErrorBody struct {
+	Error string `json:"error"`
+}
+
+// Write responds with a JSON error body and the given HTTP status. The caller
+// should return immediately after (handlers do not abort the Gin chain).
+func Write(c *gin.Context, status int, message string) {
+	if c == nil {
+		return
+	}
+	c.JSON(status, ErrorBody{Error: message})
+}
+
+// Abort responds with a JSON error body, sets the HTTP status, and aborts
+// the Gin chain so no later handlers run. Use in middleware.
+func Abort(c *gin.Context, status int, message string) {
+	if c == nil {
+		return
+	}
+	c.AbortWithStatusJSON(status, ErrorBody{Error: message})
+}

--- a/pkg/httperr/httperr_test.go
+++ b/pkg/httperr/httperr_test.go
@@ -1,0 +1,34 @@
+package httperr
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	Write(c, http.StatusTeapot, "short and stout")
+	assert.Equal(t, http.StatusTeapot, w.Code)
+	var body ErrorBody
+	assert.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.Equal(t, "short and stout", body.Error)
+}
+
+func TestAbort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	Abort(c, http.StatusForbidden, "nope")
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.True(t, c.IsAborted())
+	var body ErrorBody
+	assert.NoError(t, json.NewDecoder(w.Body).Decode(&body))
+	assert.Equal(t, "nope", body.Error)
+}

--- a/pkg/middleware/api_key.go
+++ b/pkg/middleware/api_key.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"sync"
 
+	"golang-rest-api-template/pkg/httperr"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -88,8 +90,7 @@ func APIKeyAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		secret := apiSecretCopy()
 		if len(secret) < MinAPISecretKeyBytes {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "API secret key not configured"})
-			c.Abort()
+			httperr.Abort(c, http.StatusServiceUnavailable, "API secret key not configured")
 			return
 		}
 		apiKey := c.GetHeader("X-API-Key")
@@ -97,9 +98,6 @@ func APIKeyAuth() gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		c.JSON(http.StatusUnauthorized, gin.H{
-			"error": "Unauthorized",
-		})
-		c.Abort()
+		httperr.Abort(c, http.StatusUnauthorized, "Unauthorized")
 	}
 }

--- a/pkg/middleware/jwt_auth.go
+++ b/pkg/middleware/jwt_auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"golang-rest-api-template/pkg/auth"
+	"golang-rest-api-template/pkg/httperr"
 	"net/http"
 	"strings"
 
@@ -21,21 +22,18 @@ func JWTAuth() gin.HandlerFunc {
 		const BearerSchema = "Bearer "
 		header := c.GetHeader("Authorization")
 		if header == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Missing Authorization Header"})
-			c.Abort()
+			httperr.Abort(c, http.StatusUnauthorized, "Missing Authorization Header")
 			return
 		}
 
 		if !strings.HasPrefix(header, BearerSchema) {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid Authorization Header"})
-			c.Abort()
+			httperr.Abort(c, http.StatusUnauthorized, "Invalid Authorization Header")
 			return
 		}
 
 		signingKey := auth.JWTSigningKey()
 		if len(signingKey) < auth.MinJWTSecretKeyBytes {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "JWT signing key not configured"})
-			c.Abort()
+			httperr.Abort(c, http.StatusServiceUnavailable, "JWT signing key not configured")
 			return
 		}
 
@@ -45,20 +43,17 @@ func JWTAuth() gin.HandlerFunc {
 		token, err := jwt.ParseWithClaims(tokenStr, claims, auth.JWTKeyFunc(signingKey))
 
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
-			c.Abort()
+			httperr.Abort(c, http.StatusUnauthorized, "Invalid token")
 			return
 		}
 
 		if !token.Valid {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
-			c.Abort()
+			httperr.Abort(c, http.StatusUnauthorized, "Invalid token")
 			return
 		}
 
 		if claims.UserID == 0 {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid token"})
-			c.Abort()
+			httperr.Abort(c, http.StatusUnauthorized, "Invalid token")
 			return
 		}
 


### PR DESCRIPTION
## Summary

Introduces `pkg/httperr` with a single JSON error shape (`ErrorBody` / `{"error":"..."}`) and two entry points: **`httperr.Write`** for handlers (write JSON then `return`) and **`httperr.Abort`** for middleware (`AbortWithStatusJSON`). Replaces repeated `gin.H{"error": ...}` across book handlers, user handlers, `JWTAuth`, and `APIKeyAuth`. Wire format is unchanged so clients and tests keep working; RFC 7807 remains a separate follow-up (#150).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

Internal refactor (no user-visible API change); none of the above categories fits exactly.

## How to test

```bash
go test ./... -race
go vet ./...
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required (N/A — response shape unchanged)
- [x] If you added or renamed **environment variables**: README and/or `.env` examples are updated (N/A)
- [x] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds (N/A)
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #119
