### PR TITLE
feat: unify JSON success envelope (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,17 @@ http://localhost:8001/swagger/index.html
 - `POST /api/v1/register`: Register a new user.
 - `GET /swagger/*`: Swagger UI (no `X-API-Key`).
 
+### JSON responses
+
+Successful `/api/v1` JSON responses use a single envelope: **`{"data": ...}`** (implemented in `pkg/httpresp`). Examples: `GET /api/v1/` returns `{"data":"ok"}`; book list and book CRUD return the resource or collection inside `data`; `POST /api/v1/login` returns `{"data":{"token":"<jwt>"}}`; `POST /api/v1/register` returns `{"data":{"message":"Registration successful"}}`.
+
+Error responses use **`{"error":"..."}`** (`pkg/httperr`). RFC 7807-style problem details are not used yet.
+
 ### Authentication
 
 Under **`/api/v1`**, every route **except** `GET /api/v1/` (health) requires the **`X-API-Key`** header matching **`API_SECRET_KEY`** (service-to-service gate).
 
-Book **mutations** (`POST`, `PUT`, `PATCH`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain via `/api/v1/register` and `/api/v1/login`). Book **reads** (`GET` list and `GET` by id) require the API key only.
+Book **mutations** (`POST`, `PUT`, `PATCH`, and `DELETE` on `/api/v1/books` and `/api/v1/books/:id`) also require a valid user JWT in `Authorization: Bearer <token>` (obtain a token from `POST /api/v1/login`; the JWT string is at **`data.token`** in the JSON body). Book **reads** (`GET` list and `GET` by id) require the API key only.
 
 ```bash
 curl -H "X-API-Key: <YOUR_API_KEY>" http://localhost:8001/api/v1/books
@@ -269,7 +275,7 @@ pytest -v tests/e2e.py
 
 The tests will perform the following actions:
 
-1. Register a new user and obtain a JWT token.
+1. Register a new user, log in, and obtain a JWT from the login response (`data.token`).
 2. Create a new book in the system.
 3. Retrieve all books and verify the created book is present.
 4. Retrieve a specific book by its ID.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -39,9 +39,9 @@ const docTemplate = `{
                 "summary": "ping example",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Health payload in standard envelope",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.HealthOKBody"
                         }
                     }
                 }
@@ -442,9 +442,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "JWT Token",
+                        "description": "JWT in standard envelope",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.LoginAPIResponse"
                         }
                     },
                     "400": {
@@ -499,9 +499,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Successfully registered",
+                        "description": "Registration message in standard envelope",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.RegisterAPIResponse"
                         }
                     },
                     "400": {
@@ -565,6 +565,30 @@ const docTemplate = `{
                 }
             }
         },
+        "models.HealthOKBody": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.LoginAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LoginTokenBody"
+                }
+            }
+        },
+        "models.LoginTokenBody": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
         "models.LoginUser": {
             "type": "object",
             "required": [
@@ -587,6 +611,22 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.RegisterAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.RegisterSuccessBody"
+                }
+            }
+        },
+        "models.RegisterSuccessBody": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -33,9 +33,9 @@
                 "summary": "ping example",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Health payload in standard envelope",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.HealthOKBody"
                         }
                     }
                 }
@@ -436,9 +436,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "JWT Token",
+                        "description": "JWT in standard envelope",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.LoginAPIResponse"
                         }
                     },
                     "400": {
@@ -493,9 +493,9 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Successfully registered",
+                        "description": "Registration message in standard envelope",
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/definitions/models.RegisterAPIResponse"
                         }
                     },
                     "400": {
@@ -559,6 +559,30 @@
                 }
             }
         },
+        "models.HealthOKBody": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.LoginAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LoginTokenBody"
+                }
+            }
+        },
+        "models.LoginTokenBody": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
         "models.LoginUser": {
             "type": "object",
             "required": [
@@ -581,6 +605,22 @@
                     "type": "string"
                 },
                 "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.RegisterAPIResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.RegisterSuccessBody"
+                }
+            }
+        },
+        "models.RegisterSuccessBody": {
+            "type": "object",
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -25,6 +25,21 @@ definitions:
     - author
     - title
     type: object
+  models.HealthOKBody:
+    properties:
+      data:
+        type: string
+    type: object
+  models.LoginAPIResponse:
+    properties:
+      data:
+        $ref: '#/definitions/models.LoginTokenBody'
+    type: object
+  models.LoginTokenBody:
+    properties:
+      token:
+        type: string
+    type: object
   models.LoginUser:
     properties:
       password:
@@ -40,6 +55,16 @@ definitions:
       author:
         type: string
       title:
+        type: string
+    type: object
+  models.RegisterAPIResponse:
+    properties:
+      data:
+        $ref: '#/definitions/models.RegisterSuccessBody'
+    type: object
+  models.RegisterSuccessBody:
+    properties:
+      message:
         type: string
     type: object
   models.ReplaceBook:
@@ -79,9 +104,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Health payload in standard envelope
           schema:
-            type: string
+            $ref: '#/definitions/models.HealthOKBody'
       summary: ping example
       tags:
       - example
@@ -338,9 +363,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: JWT Token
+          description: JWT in standard envelope
           schema:
-            type: string
+            $ref: '#/definitions/models.LoginAPIResponse'
         "400":
           description: Bad Request
           schema:
@@ -374,9 +399,9 @@ paths:
       - application/json
       responses:
         "201":
-          description: Successfully registered
+          description: Registration message in standard envelope
           schema:
-            type: string
+            $ref: '#/definitions/models.RegisterAPIResponse'
         "400":
           description: Bad Request
           schema:

--- a/pkg/api/books.go
+++ b/pkg/api/books.go
@@ -8,6 +8,7 @@ import (
 
 	"golang-rest-api-template/pkg/cache"
 	"golang-rest-api-template/pkg/httperr"
+	"golang-rest-api-template/pkg/httpresp"
 	"golang-rest-api-template/pkg/middleware"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
@@ -105,10 +106,10 @@ func contextUserID(c *gin.Context) (uint, bool) {
 // @Tags example
 // @Accept json
 // @Produce json
-// @Success 200 {string} ok
+// @Success 200 {object} models.HealthOKBody "Health payload in standard envelope"
 // @Router / [get]
 func (h *bookHandler) Healthcheck(c *gin.Context) {
-	c.JSON(http.StatusOK, "ok")
+	httpresp.OK(c, "ok")
 }
 
 // FindBooks godoc
@@ -144,7 +145,7 @@ func (h *bookHandler) FindBooks(c *gin.Context) {
 		}
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": books})
+	httpresp.OK(c, books)
 }
 
 // CreateBook godoc
@@ -177,7 +178,7 @@ func (h *bookHandler) CreateBook(c *gin.Context) {
 		httperr.Write(c, http.StatusInternalServerError, "Failed to create book")
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"data": book})
+	httpresp.Created(c, book)
 }
 
 // FindBook godoc
@@ -204,7 +205,7 @@ func (h *bookHandler) FindBook(c *gin.Context) {
 		httperr.Write(c, http.StatusInternalServerError, "Failed to load book")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": book})
+	httpresp.OK(c, book)
 }
 
 // UpdateBook godoc
@@ -252,7 +253,7 @@ func (h *bookHandler) UpdateBook(c *gin.Context) {
 		httperr.Write(c, http.StatusInternalServerError, "Failed to update book")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": book})
+	httpresp.OK(c, book)
 }
 
 // PatchBook godoc
@@ -304,7 +305,7 @@ func (h *bookHandler) PatchBook(c *gin.Context) {
 		httperr.Write(c, http.StatusInternalServerError, "Failed to update book")
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"data": book})
+	httpresp.OK(c, book)
 }
 
 // DeleteBook godoc

--- a/pkg/api/books_test.go
+++ b/pkg/api/books_test.go
@@ -67,9 +67,12 @@ func TestHealthcheck(t *testing.T) {
 	// Call the actual Healthcheck method
 	h.Healthcheck(c)
 
-	// Check the response
 	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.Equal(t, "\"ok\"", recorder.Body.String())
+	var health struct {
+		Data string `json:"data"`
+	}
+	assert.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &health))
+	assert.Equal(t, "ok", health.Data)
 }
 
 func TestParseIDParamNilContext(t *testing.T) {

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"golang-rest-api-template/pkg/httperr"
+	"golang-rest-api-template/pkg/httpresp"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 	"golang-rest-api-template/pkg/service"
@@ -38,7 +39,7 @@ func NewUserHandler(store repository.UserPersistence) *userHandler {
 // @Accept  json
 // @Produce  json
 // @Param   user     body    models.LoginUser     true        "User login object"
-// @Success 200 {string} string "JWT Token"
+// @Success 200 {object} models.LoginAPIResponse "JWT in standard envelope"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 401 {string} string "Unauthorized"
 // @Failure 500 {string} string "Internal Server Error"
@@ -61,7 +62,7 @@ func (h *userHandler) LoginHandler(c *gin.Context) {
 		}
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"token": token})
+	httpresp.OK(c, models.LoginTokenBody{Token: token})
 }
 
 // RegisterHandler godoc
@@ -73,7 +74,7 @@ func (h *userHandler) LoginHandler(c *gin.Context) {
 // @Accept  json
 // @Produce  json
 // @Param   user     body    models.LoginUser     true        "User registration object"
-// @Success 201 {string} string	"Successfully registered"
+// @Success 201 {object} models.RegisterAPIResponse "Registration message in standard envelope"
 // @Failure 400 {string} string "Bad Request"
 // @Failure 409 {string} string "Conflict"
 // @Failure 500 {string} string "Internal Server Error"
@@ -95,5 +96,5 @@ func (h *userHandler) RegisterHandler(c *gin.Context) {
 		}
 		return
 	}
-	c.JSON(http.StatusCreated, gin.H{"message": "Registration successful"})
+	httpresp.Created(c, models.RegisterSuccessBody{Message: "Registration successful"})
 }

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -59,7 +59,13 @@ func TestLoginHandlerSuccess(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), "token")
+	var loginBody struct {
+		Data struct {
+			Token string `json:"token"`
+		} `json:"data"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &loginBody))
+	assert.NotEmpty(t, loginBody.Data.Token)
 }
 
 func TestLoginHandlerInvalidJSON(t *testing.T) {

--- a/pkg/httpresp/httpresp.go
+++ b/pkg/httpresp/httpresp.go
@@ -1,0 +1,27 @@
+package httpresp
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type envelope[T any] struct {
+	Data T `json:"data"`
+}
+
+// OK writes HTTP 200 with the standard JSON envelope {"data": <payload>}.
+func OK[T any](c *gin.Context, data T) {
+	if c == nil {
+		return
+	}
+	c.JSON(http.StatusOK, envelope[T]{Data: data})
+}
+
+// Created writes HTTP 201 with the standard JSON envelope {"data": <payload>}.
+func Created[T any](c *gin.Context, data T) {
+	if c == nil {
+		return
+	}
+	c.JSON(http.StatusCreated, envelope[T]{Data: data})
+}

--- a/pkg/httpresp/httpresp_test.go
+++ b/pkg/httpresp/httpresp_test.go
@@ -1,0 +1,42 @@
+package httpresp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOKStringEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	OK(c, "ok")
+	assert.Equal(t, http.StatusOK, w.Code)
+	var out struct {
+		Data string `json:"data"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, "ok", out.Data)
+}
+
+func TestCreatedStructEnvelope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	type item struct {
+		ID int `json:"id"`
+	}
+	Created(c, item{ID: 42})
+	assert.Equal(t, http.StatusCreated, w.Code)
+	var out struct {
+		Data struct {
+			ID int `json:"id"`
+		} `json:"data"`
+	}
+	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &out))
+	assert.Equal(t, 42, out.Data.ID)
+}

--- a/pkg/models/api_json.go
+++ b/pkg/models/api_json.go
@@ -1,0 +1,16 @@
+package models
+
+// HealthOKBody documents GET /api/v1/ 200 JSON (standard success envelope).
+type HealthOKBody struct {
+	Data string `json:"data"`
+}
+
+// LoginAPIResponse documents POST /login 200 JSON.
+type LoginAPIResponse struct {
+	Data LoginTokenBody `json:"data"`
+}
+
+// RegisterAPIResponse documents POST /register 201 JSON.
+type RegisterAPIResponse struct {
+	Data RegisterSuccessBody `json:"data"`
+}

--- a/pkg/models/user.go
+++ b/pkg/models/user.go
@@ -7,6 +7,16 @@ type LoginUser struct {
 	Password string `json:"password" binding:"required"`
 }
 
+// LoginTokenBody is the "data" object returned by POST /login on success.
+type LoginTokenBody struct {
+	Token string `json:"token"`
+}
+
+// RegisterSuccessBody is the "data" object returned by POST /register on success.
+type RegisterSuccessBody struct {
+	Message string `json:"message"`
+}
+
 type User struct {
 	ID        uint      `json:"id" gorm:"primary_key"`
 	Username  string    `json:"username" gorm:"unique"`

--- a/tests/e2e.py
+++ b/tests/e2e.py
@@ -36,8 +36,10 @@ def get_jwt_token():
 
     assert login_response.status_code == 200, f"User login failed: {login_response.status_code}"
 
-    # Extracting JWT token from login response
-    jwt_token = login_response.json().get("token")
+    # Extracting JWT token from login response (standard envelope)
+    body = login_response.json()
+    data = body.get("data") or {}
+    jwt_token = data.get("token") if isinstance(data, dict) else None
     assert jwt_token is not None, "JWT token not found in login response"
 
     return jwt_token


### PR DESCRIPTION
## Summary

Standardizes **successful** JSON on `{"data": ...}` across `/api/v1` using **`pkg/httpresp`** (`OK` / `Created`). Health is now `{"data":"ok"}` instead of a bare JSON string; login returns `{"data":{"token":"..."}}`; register returns `{"data":{"message":"..."}}`; book endpoints already exposed resources under `data` and now use the same helper for consistency.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

**Impact:** clients that parsed **`token`** or **`message`** at the top level of login/register responses must read **`data.token`** and **`data.message`** instead. Book list/detail payloads were already under `data`; shape unchanged. README and Swagger updated accordingly.

## How to test

```bash
go test ./... -race
go vet ./...
make setup
```

Optional E2E (requires running API, `BASE_URL`, `API_KEY`):

```bash
pytest -v tests/e2e.py
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required
- [x] If you added or renamed **environment variables**: README and/or `.env` examples are updated (N/A)
- [x] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds (N/A)
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #120
