### PR TITLE
refactor: typed username conflict + Mongo setup errors (#122)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,7 +77,10 @@ func main() {
 	if db == nil {
 		log.Fatal("database: could not connect or migrate (see logs above)")
 	}
-	mongo := database.SetupMongoDB()
+	mongo, err := database.SetupMongoDB()
+	if err != nil {
+		log.Fatalf("mongo: %v", err)
+	}
 	logger, err := zap.NewProduction()
 	if err != nil {
 		log.Fatalf("logger: %v", err)

--- a/pkg/database/mongo.go
+++ b/pkg/database/mongo.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"time"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -19,18 +21,20 @@ func mongoConnectionURI() string {
 // SetupMongoDB connects to MongoDB and returns the application logs collection.
 // It reads MONGODB_URI (e.g. mongodb://mongo:27017 under Docker Compose); if unset,
 // it defaults to mongodb://localhost:27017 for local runs against a host-mapped port.
-func SetupMongoDB() *mongo.Collection {
+func SetupMongoDB() (*mongo.Collection, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	clientOptions := options.Client().ApplyURI(mongoConnectionURI())
-	client, err := mongo.Connect(context.TODO(), clientOptions)
+	client, err := mongo.Connect(ctx, clientOptions)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("mongo connect: %w", err)
 	}
 
-	// Check the connection
-	err = client.Ping(context.TODO(), nil)
-	if err != nil {
-		panic(err)
+	if err := client.Ping(ctx, nil); err != nil {
+		_ = client.Disconnect(context.Background())
+		return nil, fmt.Errorf("mongo ping: %w", err)
 	}
 
-	return client.Database("logging").Collection("logs")
+	return client.Database("logging").Collection("logs"), nil
 }

--- a/pkg/repository/errors.go
+++ b/pkg/repository/errors.go
@@ -1,0 +1,8 @@
+package repository
+
+import "errors"
+
+// ErrUserUsernameConflict is returned by UserPersistence.Create when the insert
+// violates the unique username constraint. Callers should use errors.Is
+// instead of matching driver-specific strings.
+var ErrUserUsernameConflict = errors.New("repository: username already taken")

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -21,3 +21,8 @@ func TestIsUserNotFound(t *testing.T) {
 	assert.False(t, IsUserNotFound(errors.New("other")))
 	assert.True(t, IsUserNotFound(errors.Join(gorm.ErrRecordNotFound, errors.New("wrap"))))
 }
+
+func TestErrUserUsernameConflictIsDistinct(t *testing.T) {
+	assert.NotNil(t, ErrUserUsernameConflict)
+	assert.False(t, errors.Is(ErrUserUsernameConflict, gorm.ErrRecordNotFound))
+}

--- a/pkg/repository/user_gorm.go
+++ b/pkg/repository/user_gorm.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	"golang-rest-api-template/pkg/models"
 
@@ -27,7 +29,28 @@ func (s *GormUserStore) FindByUsername(username string) (*models.User, error) {
 }
 
 func (s *GormUserStore) Create(user *models.User) error {
-	return s.db.Create(user).Error
+	err := s.db.Create(user).Error
+	if err == nil {
+		return nil
+	}
+	if isUsernameUniqueConstraintError(err) {
+		return fmt.Errorf("%w: %v", ErrUserUsernameConflict, err)
+	}
+	return err
+}
+
+func isUsernameUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	s := strings.ToLower(err.Error())
+	if strings.Contains(s, "unique constraint failed") {
+		return true
+	}
+	return strings.Contains(s, "duplicate key") && strings.Contains(s, "unique")
 }
 
 // IsUserNotFound reports whether err is a missing-user lookup from GORM.

--- a/pkg/repository/user_gorm_test.go
+++ b/pkg/repository/user_gorm_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"testing"
 
 	"golang-rest-api-template/pkg/auth"
@@ -61,4 +62,14 @@ func TestGormUserStoreCreateDuplicateUsername(t *testing.T) {
 
 	err = s.Create(&models.User{Username: "dup", Password: hash})
 	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrUserUsernameConflict)
+}
+
+func TestIsUsernameUniqueConstraintError(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isUsernameUniqueConstraintError(gorm.ErrDuplicatedKey))
+	assert.True(t, isUsernameUniqueConstraintError(errors.New("UNIQUE constraint failed: users.username")))
+	assert.True(t, isUsernameUniqueConstraintError(errors.New(`duplicate key value violates unique constraint "users_username_key"`)))
+	assert.False(t, isUsernameUniqueConstraintError(nil))
+	assert.False(t, isUsernameUniqueConstraintError(errors.New("connection reset")))
 }

--- a/pkg/service/user_service.go
+++ b/pkg/service/user_service.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/models"
 	"golang-rest-api-template/pkg/repository"
 
 	"golang.org/x/crypto/bcrypt"
-	"gorm.io/gorm"
 )
 
 // Sentinel errors for login / registration.
@@ -61,7 +59,7 @@ func (s *UserService) Register(_ context.Context, username, password string) err
 	}
 	newUser := &models.User{Username: username, Password: hashedPassword}
 	if err := s.users.Create(newUser); err != nil {
-		if registerUsernameConflict(err) {
+		if errors.Is(err, repository.ErrUserUsernameConflict) {
 			return ErrRegisterConflict
 		}
 		return fmtError(ErrRegisterSave, err)
@@ -71,21 +69,4 @@ func (s *UserService) Register(_ context.Context, username, password string) err
 
 func fmtError(sentinel error, cause error) error {
 	return fmt.Errorf("%w: %v", sentinel, cause)
-}
-
-func registerUsernameConflict(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, gorm.ErrDuplicatedKey) {
-		return true
-	}
-	s := strings.ToLower(err.Error())
-	if strings.Contains(s, "unique constraint failed") {
-		return true
-	}
-	if strings.Contains(s, "duplicate key") && strings.Contains(s, "unique") {
-		return true
-	}
-	return false
 }

--- a/pkg/service/user_service_test.go
+++ b/pkg/service/user_service_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"golang-rest-api-template/pkg/auth"
 	"golang-rest-api-template/pkg/models"
+	"golang-rest-api-template/pkg/repository"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/bcrypt"
@@ -91,18 +93,7 @@ func TestUserServiceLoginSuccess(t *testing.T) {
 func TestUserServiceRegisterConflictDuplicatedKey(t *testing.T) {
 	store := &fakeUserStore{
 		createFn: func(user *models.User) error {
-			return gorm.ErrDuplicatedKey
-		},
-	}
-	svc := NewUserService(store)
-	err := svc.Register(context.Background(), "dup", "password123")
-	assert.ErrorIs(t, err, ErrRegisterConflict)
-}
-
-func TestUserServiceRegisterConflictSQLiteMessage(t *testing.T) {
-	store := &fakeUserStore{
-		createFn: func(user *models.User) error {
-			return errors.New("UNIQUE constraint failed: users.username")
+			return fmt.Errorf("%w: %v", repository.ErrUserUsernameConflict, gorm.ErrDuplicatedKey)
 		},
 	}
 	svc := NewUserService(store)


### PR DESCRIPTION
## Summary

Implements **[#122](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/122)** in two parts:

1. **Typed domain error for duplicate registration:** `repository.ErrUserUsernameConflict` is returned from `GormUserStore.Create` when a unique username constraint fails (`errors.Is` on `gorm.ErrDuplicatedKey` plus the same SQLite/Postgres message heuristics, centralized in the repository). `UserService.Register` maps conflicts with **`errors.Is(err, repository.ErrUserUsernameConflict)`** only—no string matching in the service layer.

2. **Mongo setup:** `database.SetupMongoDB` now returns **`(*mongo.Collection, error)`** with a bounded connect/ping context, disconnects the client if ping fails, and **`main`** exits via `log.Fatalf` instead of a panic from Mongo initialization.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (describe impact below)
- [ ] Documentation only
- [ ] Build / CI / tooling
- [ ] Dependency update

Internal architecture / reliability improvement; **public Go API change** only for callers of `SetupMongoDB` (signature now includes `error`).

## How to test

```bash
go test ./... -race
go vet ./...
```

## Checklist

- [x] `go test ./... -race` passes locally
- [x] If you changed **routes, handlers, or models**: Swagger was regenerated (`swag init` / project `Makefile` `setup` target) and `docs/` is updated if required (N/A)
- [x] If you added or renamed **environment variables**: README and/or `.env` examples are updated (N/A)
- [x] If you changed **Docker or compose**: `docker compose build` (or `make build-docker`) still succeeds (N/A)
- [x] No new secrets, credentials, or production keys committed

## Related issues

Closes #122
