### PR TITLE
feat: request context timeout for /api/v1 (#127)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,5 @@ API_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
 # Optional: max request body size in bytes for POST/PUT/PATCH (default 1048576 = 1 MiB).
 # REQUEST_MAX_BODY_BYTES=2097152
+# Per-request context timeout for /api/v1 only (Go duration). Default 60s. Use 0 to disable.
+# REQUEST_CONTEXT_TIMEOUT=60s

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Names below match `os.Getenv` usage in this repository:
 | `GIN_MODE` | Standard Gin variable: `debug` (default if unset), `release` (enables Security + XSS middleware in `pkg/api/router.go`), or `test` |
 | `GIN_TRUSTED_PROXIES` | Optional comma-separated CIDRs trusted for `X-Forwarded-For` / `ClientIP` (`pkg/api/router.go`). If unset, only the direct peer address is used. |
 | `REQUEST_MAX_BODY_BYTES` | Optional cap on JSON/body bytes for `POST`/`PUT`/`PATCH` (default `1048576`, i.e. 1 MiB; `pkg/middleware/max_body.go`). |
+| `REQUEST_CONTEXT_TIMEOUT` | Optional per-request deadline for **`/api/v1/**` only** (Go duration, e.g. `60s`); default `60s`. Set to `0`, `off`, or `none` to disable (`pkg/middleware/request_timeout.go`). Probes and Swagger are outside this group. |
 
 To generate URL-safe random values for `JWT_SECRET_KEY` and `API_SECRET_KEY`, run:
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -47,6 +47,7 @@ func NewRouter(logger *zap.Logger, mongoCollection *mongo.Collection, db *gorm.D
 
 	docs.SwaggerInfo.BasePath = "/api/v1"
 	v1 := r.Group("/api/v1")
+	v1.Use(middleware.RequestContextTimeoutFromEnv())
 	{
 		v1.GET("/", books.Healthcheck)
 		v1.GET("/books", middleware.APIKeyAuth(), books.FindBooks)

--- a/pkg/middleware/request_timeout.go
+++ b/pkg/middleware/request_timeout.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const defaultRequestContextTimeout = 60 * time.Second
+
+// RequestContextTimeout returns middleware that attaches a derived
+// context.WithTimeout to c.Request, so handlers and services using
+// c.Request.Context() inherit a deadline (#127). If d <= 0, the middleware is a
+// no-op.
+func RequestContextTimeout(d time.Duration) gin.HandlerFunc {
+	if d <= 0 {
+		return func(c *gin.Context) { c.Next() }
+	}
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), d)
+		defer cancel()
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+// RequestContextTimeoutFromEnv is like RequestContextTimeout with a duration
+// from REQUEST_CONTEXT_TIMEOUT (Go duration syntax). Empty uses 60s. "0",
+// "off", or "none" disables the middleware. Invalid values log a warning and
+// fall back to the default.
+func RequestContextTimeoutFromEnv() gin.HandlerFunc {
+	return RequestContextTimeout(requestContextTimeoutDurationFromEnv())
+}
+
+func requestContextTimeoutDurationFromEnv() time.Duration {
+	s := strings.TrimSpace(os.Getenv("REQUEST_CONTEXT_TIMEOUT"))
+	if s == "" {
+		return defaultRequestContextTimeout
+	}
+	if strings.EqualFold(s, "0") || strings.EqualFold(s, "off") || strings.EqualFold(s, "none") {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		log.Printf("middleware: invalid REQUEST_CONTEXT_TIMEOUT=%q, using default %v", s, defaultRequestContextTimeout)
+		return defaultRequestContextTimeout
+	}
+	return d
+}

--- a/pkg/middleware/request_timeout_test.go
+++ b/pkg/middleware/request_timeout_test.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestContextTimeoutNoOp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequestContextTimeout(0))
+	r.GET("/ok", func(c *gin.Context) {
+		assert.NoError(t, c.Request.Context().Err())
+		c.Status(http.StatusNoContent)
+	})
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ok", nil))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestRequestContextTimeoutDurationFromEnv(t *testing.T) {
+	t.Run("empty uses default", func(t *testing.T) {
+		t.Setenv("REQUEST_CONTEXT_TIMEOUT", "")
+		assert.Equal(t, defaultRequestContextTimeout, requestContextTimeoutDurationFromEnv())
+	})
+	t.Run("off disables", func(t *testing.T) {
+		t.Setenv("REQUEST_CONTEXT_TIMEOUT", "off")
+		assert.Equal(t, time.Duration(0), requestContextTimeoutDurationFromEnv())
+	})
+	t.Run("parse duration", func(t *testing.T) {
+		t.Setenv("REQUEST_CONTEXT_TIMEOUT", "2m")
+		assert.Equal(t, 2*time.Minute, requestContextTimeoutDurationFromEnv())
+	})
+}
+
+func TestRequestContextTimeoutFiresBeforeSlowWork(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RequestContextTimeout(40 * time.Millisecond))
+	r.GET("/slow", func(c *gin.Context) {
+		ctx := c.Request.Context()
+		select {
+		case <-time.After(500 * time.Millisecond):
+			c.Status(http.StatusOK)
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				c.AbortWithStatus(http.StatusGatewayTimeout)
+				return
+			}
+			c.AbortWithStatus(http.StatusInternalServerError)
+		}
+	})
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/slow", nil))
+	assert.Less(t, time.Since(start), 200*time.Millisecond, "handler should stop when context times out")
+	assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+}


### PR DESCRIPTION
## Summary

Adds middleware that wraps `c.Request` with `context.WithTimeout` so code using `c.Request.Context()` respects a per-request deadline on **`/api/v1/**` only** (health/Swagger routes unchanged).

## Configuration

- **`REQUEST_CONTEXT_TIMEOUT`**: Go duration (e.g. `60s`, `2m`). Empty defaults to **60s**. Set to `0`, `off`, or `none` to disable.

## Files

- `pkg/middleware/request_timeout.go` — middleware + env parsing
- `pkg/middleware/request_timeout_test.go` — unit tests
- `pkg/api/router.go` — register on `v1` group
- `README.md`, `.env.example` — document env var

Fixes #127

Made with [Cursor](https://cursor.com)