### PR TITLE
feat(auth): tune bcrypt cost for registration (#128)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ MONGODB_URI=mongodb://localhost:27017
 # Generate with: go run ./scripts/generate_key.go
 JWT_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 
+# Optional: bcrypt cost for new password hashes (10–31; default 12). Omit for default.
+# BCRYPT_COST=12
+
 # Shared secret for X-API-Key (raw string length must be at least 32 bytes).
 API_SECRET_KEY=replace-me-generate-with-scripts-generate-key
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Names below match `os.Getenv` usage in this repository:
 | `REDIS_READ_TIMEOUT` | Read timeout (default `3s`) |
 | `REDIS_WRITE_TIMEOUT` | Write timeout (default `3s`) |
 | `JWT_SECRET_KEY` | Secret for signing JWTs (`pkg/auth/auth.go`) |
+| `BCRYPT_COST` | Optional bcrypt work factor for **new** password hashes (integer `10`–`31`; default **`12`**, was 14). Values below `10` clamp to `10` with a log line. See [#128](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/128). |
 | `API_SECRET_KEY` | Secret compared to the `X-API-Key` header (`pkg/middleware/api_key.go`) |
 | `GIN_MODE` | Standard Gin variable: `debug` (default if unset), `release` (enables Security + XSS middleware in `pkg/api/router.go`), or `test` |
 | `GIN_TRUSTED_PROXIES` | Optional comma-separated CIDRs trusted for `X-Forwarded-For` / `ClientIP` (`pkg/api/router.go`). If unset, only the direct peer address is used. |

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -5,6 +5,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,6 +19,14 @@ import (
 // MinJWTSecretKeyBytes is the minimum accepted length for the HMAC JWT signing
 // secret (raw bytes, not base64-decoded length).
 const MinJWTSecretKeyBytes = 32
+
+// defaultBcryptCost is the bcrypt work factor for new password hashes (#128).
+// The audit recommended evaluating the 10–12 range; 12 balances UX and strength.
+const defaultBcryptCost = 12
+
+// minBcryptCost is the lowest cost we accept from BCRYPT_COST (below this is weak
+// for production-style deployments).
+const minBcryptCost = 10
 
 var (
 	// ErrJWTSigningKeyNotConfigured is returned by GenerateToken when
@@ -88,8 +100,34 @@ func JWTKeyFunc(key []byte) jwt.Keyfunc {
 }
 
 func HashPassword(password string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), 14)
+	cost := bcryptCostForPasswordHashing()
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), cost)
 	return string(bytes), err
+}
+
+// bcryptCostForPasswordHashing returns the bcrypt cost for HashPassword.
+// BCRYPT_COST overrides the default (12); it must parse as an integer in
+// [minBcryptCost, bcrypt.MaxCost]. Invalid or out-of-range values log a warning
+// and fall back to defaultBcryptCost.
+func bcryptCostForPasswordHashing() int {
+	s := strings.TrimSpace(os.Getenv("BCRYPT_COST"))
+	if s == "" {
+		return defaultBcryptCost
+	}
+	c, err := strconv.Atoi(s)
+	if err != nil {
+		log.Printf("auth: invalid BCRYPT_COST=%q, using default cost %d", s, defaultBcryptCost)
+		return defaultBcryptCost
+	}
+	if c < bcrypt.MinCost || c > bcrypt.MaxCost {
+		log.Printf("auth: invalid BCRYPT_COST=%d (must be %d–%d), using default cost %d", c, bcrypt.MinCost, bcrypt.MaxCost, defaultBcryptCost)
+		return defaultBcryptCost
+	}
+	if c < minBcryptCost {
+		log.Printf("auth: BCRYPT_COST=%d is below recommended minimum %d, using %d", c, minBcryptCost, minBcryptCost)
+		return minBcryptCost
+	}
+	return c
 }
 
 // GenerateToken issues an HS256 JWT with username and user_id claims. userID must

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func init() {
@@ -23,6 +24,58 @@ func TestHashPassword(t *testing.T) {
 	hashedPassword, err := HashPassword(password)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, hashedPassword)
+}
+
+func TestHashPasswordUsesDefaultBcryptCost(t *testing.T) {
+	t.Setenv("BCRYPT_COST", "")
+	hash, err := HashPassword("secret")
+	if !assert.NoError(t, err) {
+		return
+	}
+	cost, err := bcrypt.Cost([]byte(hash))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, defaultBcryptCost, cost)
+}
+
+func TestHashPasswordUsesBCRYPT_COST(t *testing.T) {
+	t.Setenv("BCRYPT_COST", "10")
+	hash, err := HashPassword("secret")
+	if !assert.NoError(t, err) {
+		return
+	}
+	cost, err := bcrypt.Cost([]byte(hash))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, 10, cost)
+}
+
+func TestHashPasswordClampsLowBCRYPT_COSTToMin(t *testing.T) {
+	t.Setenv("BCRYPT_COST", "8")
+	hash, err := HashPassword("secret")
+	if !assert.NoError(t, err) {
+		return
+	}
+	cost, err := bcrypt.Cost([]byte(hash))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, minBcryptCost, cost)
+}
+
+func TestHashPasswordInvalidBcryptCostEnvFallsBackToDefault(t *testing.T) {
+	t.Setenv("BCRYPT_COST", "not-a-number")
+	hash, err := HashPassword("secret")
+	if !assert.NoError(t, err) {
+		return
+	}
+	cost, err := bcrypt.Cost([]byte(hash))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, defaultBcryptCost, cost)
 }
 
 func TestGenerateToken(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements [#128](https://github.com/LAA-Software-Engineering/golang-rest-api-template/issues/128): reduce default bcrypt work factor from **14** to **12** (within the audit’s **10–12** band) for faster password hashing at registration while keeping a strong default.

## Configuration

- **`BCRYPT_COST`**: optional integer in bcrypt’s supported range (`10`–`31` recommended; bcrypt allows `4`–`31`). Empty → **12**. Non-numeric or out-of-range → log warning and **12**. Integer in `4`–`9` → clamp to **10** with a log line (recommended floor for this template).

Existing password hashes are unchanged; `CompareHashAndPassword` remains compatible.

## Tests

- `go test ./pkg/auth/... ./pkg/service/... ./pkg/api/... ./pkg/repository/... -race -count=1`

Fixes #128

Made with [Cursor](https://cursor.com)